### PR TITLE
add development environemnt configuration for chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,30 @@ REDIS_PASSWD=secret
 USER=$(whoami) docker compose --env-file .env.dev up -d
 ```
 
+### Chatbot Configuration
+
+The chatbot requires specific environment variables to run, as its backend operates on a production system. This setup ensures it connects to an accessible Freva instance and project as a hub.
+
+#### Required Environment Variables:
+Choose one of running Freva instances and get the values from there and set via environment.
+
+| Variable                 | Description                                                                          |
+| ------------------------ | ------------------------------------------------------------------------------------ |
+| `CHAT_BOT_URL`           | URL of the chatbot backend (default example: `http://vader4-icpub.lvt.dkrz.de:8502`) |
+| `CHAT_BOT_AUTH_KEY`      | Authentication key for the chatbot (set via environment variable)                    |
+| `CHAT_BOT_FREVA_CONFIG`  | Path or configuration string for Freva (set via environment variable)                |
+| `VAULT_URL`              | URL of the Vault system providing secrets (set via environment variable)             |
+| `CHAT_BOT_FREVA_PROJECT` | Name of the Freva project the chatbot should use (set via environment variable)      |
+| `FREVA_REST_URL` | URL of the freva-rest of one running freva instance (set via environment variable)      |
+
+#### Optional:
+
+| Variable   | Description                                                                     |
+| ---------- | ------------------------------------------------------------------------------- |
+| `CHAT_BOT` | Set to `"1"` to activate the chatbot, `"0"` to disable it (default is disabled) |
+
+
+
 ### Running tests
 
 There are some rudimentary tests that check the integration of `django` and the

--- a/bot/proxyviews.py
+++ b/bot/proxyviews.py
@@ -13,7 +13,14 @@ class ChatBotProxy(View):
         path = request.path
         base_url = urljoin(settings.CHAT_BOT_URL, path)
         params = request.GET.dict()
-
+        access_token = request.session.get("access_token", ""),
+        headers = {
+            "X-Freva-User-Token": f"Bearer {access_token[0]}",
+            "X-Freva-Vault-URL": settings.VAULT_URL,
+            "X-Freva-Rest-URL": settings.FREVA_REST_URL,
+            "X-Freva-Config-Path": settings.CHAT_BOT_FREVA_CONFIG,
+            "X-Freva-Project": settings.CHAT_BOT_FREVA_PROJECT,
+        }
         # adding bot auth key and freva conf
         params["auth_key"] = settings.CHAT_BOT_AUTH_KEY
         params["freva_config"] = settings.CHAT_BOT_FREVA_CONFIG
@@ -21,6 +28,7 @@ class ChatBotProxy(View):
         try:
             upstream_response = requests.get(
                 base_url[:-1],
+                headers=headers,
                 params=params,
                 stream=True
             )

--- a/django_evaluation/settings/local.py
+++ b/django_evaluation/settings/local.py
@@ -296,10 +296,18 @@ RESULT_BROWSER_FACETS = [
 ]
 MENU_ENTRIES = []
 
-CHAT_BOT_URL = "http://vader5-icpub.lvt.dkrz.de:8502"
+CHAT_BOT_URL = "http://vader4-icpub.lvt.dkrz.de:8502"
 CHAT_BOT_AUTH_KEY = os.environ.get("CHAT_BOT_AUTH_KEY")
 CHAT_BOT_FREVA_CONFIG = os.environ.get("CHAT_BOT_FREVA_CONFIG")
-
+### CHATBOT development settings
+# Since the backend of chatbot is running on an operational system
+# it is necessary to pass some configuration from a non-localhost
+# and accessible freva instance to the chatbot backend.
+# For example we can catch the project name and vault url
+# and freva_rest and freva_config from the environment variables
+VAULT_URL = os.environ.get("VAULT_URL")
+CHAT_BOT_FREVA_PROJECT = os.environ.get("CHAT_BOT_FREVA_PROJECT")
+##################################
 if os.getenv("CHAT_BOT", "0").isdigit():
     ACTIVATE_CHAT_BOT = bool(int(os.getenv("CHAT_BOT", "0")))
 else:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evaluation_system_web",
-  "version": "2505.0.0",
+  "version": "2506.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "evaluation_system_web",
-      "version": "2505.0.0",
+      "version": "2506.0.1",
       "license": "ISC",
       "dependencies": {
         "date-fns": "^2.29",


### PR DESCRIPTION
For development purposes of the chatbot, some adjustments are necessary. Since the chatbot backend runs on an operational system and, based on recent changes, it retrieves the user information using the access token header and it access the mongo using vault secret, we currently lack a proper way to test the chatbot in a local development environment.
To address this, we introduce a configuration that allows the chatbot to use an existing, accessible Freva instance. This makes it possible to run and test the chatbot locally while still interacting with the required services, like Vault and Mongo, through that Freva instance.