### PR TITLE
Custom flavour

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,7 @@ REDIS_SSL_CERTFILE=./docker/config/certs/client-cert.pem
 REDIS_SSL_KEYFILE=./docker/config/certs/client-key.pem
 REDIS_CONTAINER_CERTFILE=/certs/client-cert.pem
 REDIS_CONTAINER_KEYFILE=/certs/client-key.pem
+API_MONGO_USER=mongo
+API_MONGO_PASSWORD=secret
+API_MONGO_DB=search_stats
+API_ADMINS_TOKEN_CLAIMS=resource_access.realm-management.roles:admin

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ setup-django:
 
 setup-rest:
 	TEMP_DIR=$$(mktemp -d) && \
-	git clone https://github.com/freva-org/freva-nextgen.git $$TEMP_DIR &&\
+	git clone -b custom_flavour https://github.com/freva-org/freva-nextgen.git $$TEMP_DIR &&\
 	python -m pip install $$TEMP_DIR/freva-rest $$TEMP_DIR/freva-data-portal-worker &&\
 	rm -rf $$TEMP_DIR
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ setup-django:
 
 setup-rest:
 	TEMP_DIR=$$(mktemp -d) && \
-	git clone -b custom_flavour https://github.com/freva-org/freva-nextgen.git $$TEMP_DIR &&\
+	git clone https://github.com/freva-org/freva-nextgen.git $$TEMP_DIR &&\
 	python -m pip install $$TEMP_DIR/freva-rest $$TEMP_DIR/freva-data-portal-worker &&\
 	rm -rf $$TEMP_DIR
 

--- a/assets/js/Containers/Databrowser/DataBrowserCommand.js
+++ b/assets/js/Containers/Databrowser/DataBrowserCommand.js
@@ -56,6 +56,7 @@ function DataBrowserCommandImpl(props) {
   }
 
   function getFullCliCommand(dateSelectorToCli, bboxSelectorToCli) {
+    const effectiveFlavour = props.selectedFlavour || constants.DEFAULT_FLAVOUR;
     return (
       "freva-client databrowser data-search " +
       (props.minDate ? `time=${props.minDate}to${props.maxDate} ` : "") +
@@ -74,15 +75,14 @@ function DataBrowserCommandImpl(props) {
       (bboxSelectorToCli && props.minLon
         ? ` --bbox-select ${bboxSelectorToCli}`
         : "") +
-      (props.selectedFlavour !== constants.DEFAULT_FLAVOUR
-        ? ` --flavour ${props.selectedFlavour}`
-        : "")
+      (effectiveFlavour !== "freva" ? ` --flavour ${effectiveFlavour}` : "")
     ).trimEnd();
   }
 
   function renderCLICommand() {
     const dateSelectorToCli = getCliTimeSelector();
     const bboxSelectorToCli = getCliBBoxSelector();
+    const effectiveFlavour = props.selectedFlavour || constants.DEFAULT_FLAVOUR;
 
     return (
       <pre className="mb-1" style={{ whiteSpace: "pre-wrap" }}>
@@ -124,10 +124,9 @@ function DataBrowserCommandImpl(props) {
             <span className="fw-bold">{bboxSelectorToCli}</span>
           </React.Fragment>
         )}
-        {props.selectedFlavour !== constants.DEFAULT_FLAVOUR && (
+        {effectiveFlavour !== "freva" && (
           <React.Fragment>
-            &nbsp;--flavour{" "}
-            <span className="fw-bold">{props.selectedFlavour}</span>
+            &nbsp;--flavour <span className="fw-bold">{effectiveFlavour}</span>
           </React.Fragment>
         )}
       </pre>
@@ -136,9 +135,11 @@ function DataBrowserCommandImpl(props) {
 
   function getFullPythonCommand(dateSelectorToCli, bboxSelectorToCli) {
     let args = [];
-
-    if (props.selectedFlavour !== constants.DEFAULT_FLAVOUR) {
-      args.push(`flavour="${props.selectedFlavour}"`);
+    const effectiveFlavour = props.selectedFlavour || constants.DEFAULT_FLAVOUR;
+    // if it's only freva, we don't need to specify flavour=, in
+    // all other cases we do
+    if (effectiveFlavour !== "freva") {
+      args.push(`flavour="${effectiveFlavour}"`);
     }
 
     args = [

--- a/assets/js/Containers/Databrowser/FlavourManager.js
+++ b/assets/js/Containers/Databrowser/FlavourManager.js
@@ -22,7 +22,7 @@ import {
 class FlavourManager extends Component {
   constructor(props) {
     super(props);
-    
+
     this.state = {
       additionalFacetsVisible: false,
       showAddFlavourModal: false,
@@ -81,7 +81,7 @@ class FlavourManager extends Component {
       this.setState({ modalError: "Flavour name is required" });
       return;
     }
-    
+
     // Building the mapping from user-input form data
     const mapping = {};
     Object.entries(this.state.facetMappings).forEach(([key, value]) => {
@@ -97,15 +97,17 @@ class FlavourManager extends Component {
 
     this.setState({ modalLoading: true });
     try {
-      await this.props.dispatch(this.props.addFlavour({
-        flavour_name: this.state.flavourName,
-        mapping,
-        is_global: this.state.isGlobal
-      }));
-      
+      await this.props.dispatch(
+        this.props.addFlavour({
+          flavour_name: this.state.flavourName,
+          mapping,
+          is_global: this.state.isGlobal,
+        })
+      );
+
       // Reset the form on success and close the modal
-      this.setState({ 
-        flavourName: "", 
+      this.setState({
+        flavourName: "",
         facetMappings: {
           project: "",
           model: "",
@@ -129,17 +131,17 @@ class FlavourManager extends Component {
           rcm_version: "",
           user: "",
         },
-        isGlobal: false, 
+        isGlobal: false,
         modalError: "",
-        showAddFlavourModal: false 
+        showAddFlavourModal: false,
       });
-      
+
       this.showToast("Flavour added successfully!", "success");
     } catch (err) {
       const canAdd = this.canAddFlavour();
-      const message = canAdd ? 
-        (err.message || "Failed to add flavour") : 
-        "You don't have permission to add flavours";
+      const message = canAdd
+        ? err.message || "Failed to add flavour"
+        : "You don't have permission to add flavours";
       this.setState({ modalError: message });
       this.showToast(message, "danger");
     } finally {
@@ -151,53 +153,56 @@ class FlavourManager extends Component {
     if (event) {
       event.stopPropagation();
     }
-    
+
     // TODO: we need to still think if window.confirm is better here
     // or we need to use a modal
     this.setState({
       showDeleteConfirmModal: true,
-      flavourToDelete: { name: flavourName, isGlobal }
+      flavourToDelete: { name: flavourName, isGlobal },
     });
   }
 
   confirmDeleteFlavour = () => {
     if (this.state.flavourToDelete) {
       this.performDeleteFlavour(
-        this.state.flavourToDelete.name, 
+        this.state.flavourToDelete.name,
         this.state.flavourToDelete.isGlobal
       );
     }
-    this.setState({ 
-      showDeleteConfirmModal: false, 
-      flavourToDelete: null 
+    this.setState({
+      showDeleteConfirmModal: false,
+      flavourToDelete: null,
     });
-  }
+  };
 
   cancelDeleteFlavour = () => {
-    this.setState({ 
-      showDeleteConfirmModal: false, 
-      flavourToDelete: null 
+    this.setState({
+      showDeleteConfirmModal: false,
+      flavourToDelete: null,
     });
-  }
+  };
 
   async performDeleteFlavour(flavourName, isGlobal) {
     try {
-      await this.props.dispatch(this.props.deleteFlavour(flavourName, isGlobal));
-      
+      await this.props.dispatch(
+        this.props.deleteFlavour(flavourName, isGlobal)
+      );
+
       // IMPORTANT: If the flavour being deleted is the current one, reset to default
       // to `freva`
-      const currentFlavour = this.props.currentFlavour || this.props.defaultFlavour;
+      const currentFlavour =
+        this.props.currentFlavour || this.props.defaultFlavour;
       if (currentFlavour === flavourName) {
         this.props.onFlavourClick("freva");
       }
-      
+
       this.showToast("Flavour deleted successfully!", "success");
     } catch (err) {
-      const canDelete = this.canDeleteFlavour({ 
-        flavour_name: flavourName, 
-        owner: isGlobal ? "global" : "user" 
+      const canDelete = this.canDeleteFlavour({
+        flavour_name: flavourName,
+        owner: isGlobal ? "global" : "user",
       });
-      
+
       let message;
       if (!canDelete) {
         if (isGlobal) {
@@ -214,7 +219,7 @@ class FlavourManager extends Component {
           message = serverMessage || "Failed to delete flavour";
         }
       }
-      
+
       this.showToast(message, "danger");
     }
   }
@@ -224,13 +229,16 @@ class FlavourManager extends Component {
     if (builtInFlavours.includes(flavour.flavour_name.toLowerCase())) {
       return false;
     }
-    
+
     const currentUser = this.props.currentUser || "unknown";
     const isAdmin = this.props.isAdmin || false;
-    
-    return flavour.owner === currentUser || 
-           (isAdmin && flavour.owner === "global") ||
-           flavour.owner === "global" || flavour.owner !== "global";
+
+    return (
+      flavour.owner === currentUser ||
+      (isAdmin && flavour.owner === "global") ||
+      flavour.owner === "global" ||
+      flavour.owner !== "global"
+    );
   }
 
   canAddFlavour() {
@@ -241,14 +249,20 @@ class FlavourManager extends Component {
   }
 
   getSortedFlavours() {
-    // NOte: always global flavours are sorted first and then 
+    // NOte: always global flavours are sorted first and then
     // user flavours
     const { flavourDetails } = this.props;
-    if (!flavourDetails) {return []}
-    
+    if (!flavourDetails) {
+      return [];
+    }
+
     return [...flavourDetails].sort((a, b) => {
-      if (a.owner === "global" && b.owner !== "global") {return -1}
-      if (a.owner !== "global" && b.owner === "global") {return 1}
+      if (a.owner === "global" && b.owner !== "global") {
+        return -1;
+      }
+      if (a.owner !== "global" && b.owner === "global") {
+        return 1;
+      }
       return a.flavour_name.localeCompare(b.flavour_name);
     });
   }
@@ -256,8 +270,10 @@ class FlavourManager extends Component {
   renderFlavourDropdown() {
     const sortedFlavours = this.getSortedFlavours();
     const flavour = this.props.currentFlavour || this.props.defaultFlavour;
-    const currentFlavour = sortedFlavours.find(f => f.flavour_name === flavour);
-  
+    const currentFlavour = sortedFlavours.find(
+      (f) => f.flavour_name === flavour
+    );
+
     return (
       <>
         <style>{`
@@ -273,141 +289,166 @@ class FlavourManager extends Component {
             box-shadow: 0 0 0 0.2rem rgba(3, 105, 161, 0.25) !important;
           }
         `}</style>
-        
+
         <div className="position-relative me-1">
-        <ButtonGroup>
-          <Dropdown 
-            onToggle={(isOpen) => {
-              if (!isOpen) {
-                this.setState({ deleteMode: false });
-              }
-            }}
-          >
-            <Dropdown.Toggle 
-              variant="outline-secondary" 
-              id="flavour-dropdown"
-              className="d-flex align-items-center dropdown-toggle-custom"
-              style={{
-                minWidth: '120px',
-                fontSize: '0.9rem'
+          <ButtonGroup>
+            <Dropdown
+              onToggle={(isOpen) => {
+                if (!isOpen) {
+                  this.setState({ deleteMode: false });
+                }
               }}
             >
-              <div className="d-flex align-items-center w-100">
-                {currentFlavour?.owner === "global" ? (
-                  <FaGlobe
-                    className="me-2"
-                    style={{ 
-                      fontSize: '0.8rem', 
-                      color: '#0369a1' 
-                    }} 
-                  />
-                ) : (
-                  <FaUser
-                    className="me-2" 
-                    style={{ 
-                      fontSize: '0.8rem', 
-                      color: '#475569' 
-                    }} 
-                  />
-                )}
-                <span className="text-truncate">{flavour}</span>
-              </div>
-            </Dropdown.Toggle>
-  
-            <Dropdown.Menu
-              style={{ minWidth: '160px' }}
-            >
-              {sortedFlavours.map((flavourDetail) => (
-                <div key={flavourDetail.flavour_name} className="position-relative">
-                  <Dropdown.Item
-                    active={flavour === flavourDetail.flavour_name}
-                    onClick={() => this.props.onFlavourClick(flavourDetail.flavour_name)}
-                    className="d-flex align-items-center custom-dropdown-item"
-                    style={{ 
-                      paddingRight: this.state.deleteMode && this.canDeleteFlavour(flavourDetail) ? '50px' : '16px',
-                      fontSize: '0.9rem'
-                    }}
-                  >
-                    {flavourDetail.owner === "global" ? (
-                      <FaGlobe className="text-primary me-2 icon-white" style={{ fontSize: '0.8rem' }} />
-                    ) : (
-                      <FaUser className="text-secondary me-2 icon-white" style={{ fontSize: '0.8rem' }} />
-                    )}
-                    <span>{flavourDetail.flavour_name}</span>
-                  </Dropdown.Item>
-                  
-                  {this.state.deleteMode && this.canDeleteFlavour(flavourDetail) && (
-                    <Button
-                      variant="link"
-                      size="sm"
-                      className="position-absolute text-danger p-0"
-                      onClick={(e) => this.handleDeleteFlavour(flavourDetail.flavour_name, flavourDetail.owner === "global", e)}
-                      title="Delete flavour"
+              <Dropdown.Toggle
+                variant="outline-secondary"
+                id="flavour-dropdown"
+                className="d-flex align-items-center dropdown-toggle-custom"
+                style={{
+                  minWidth: "120px",
+                  fontSize: "0.9rem",
+                }}
+              >
+                <div className="d-flex align-items-center w-100">
+                  {currentFlavour?.owner === "global" ? (
+                    <FaGlobe
+                      className="me-2"
                       style={{
-                        right: '12px',
-                        top: '50%',
-                        transform: 'translateY(-50%)',
-                        width: '20px',
-                        height: '20px',
-                        fontSize: '0.8rem'
+                        fontSize: "0.8rem",
+                        color: "#0369a1",
+                      }}
+                    />
+                  ) : (
+                    <FaUser
+                      className="me-2"
+                      style={{
+                        fontSize: "0.8rem",
+                        color: "#475569",
+                      }}
+                    />
+                  )}
+                  <span className="text-truncate">{flavour}</span>
+                </div>
+              </Dropdown.Toggle>
+
+              <Dropdown.Menu style={{ minWidth: "160px" }}>
+                {sortedFlavours.map((flavourDetail) => (
+                  <div
+                    key={flavourDetail.flavour_name}
+                    className="position-relative"
+                  >
+                    <Dropdown.Item
+                      active={flavour === flavourDetail.flavour_name}
+                      onClick={() =>
+                        this.props.onFlavourClick(flavourDetail.flavour_name)
+                      }
+                      className="d-flex align-items-center custom-dropdown-item"
+                      style={{
+                        paddingRight:
+                          this.state.deleteMode &&
+                          this.canDeleteFlavour(flavourDetail)
+                            ? "50px"
+                            : "16px",
+                        fontSize: "0.9rem",
                       }}
                     >
-                      <FaTrash />
-                    </Button>
-                  )}
-                </div>
-              ))}
-              
-              <Dropdown.Divider />
-              
-              <Dropdown.Item 
-                onClick={() => this.setState({ showAddFlavourModal: true })}
-                className="text-success"
-                style={{ fontSize: '0.9rem' }}
-              >
-                <FaPlus className="me-2" style={{ fontSize: '0.8rem' }} />
-                Add Flavour
-              </Dropdown.Item>
-              
-              <Dropdown.Item 
-                onClick={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                  this.setState({ deleteMode: !this.state.deleteMode });
-                }}
-                className={this.state.deleteMode ? "text-danger" : "text-muted"}
-                style={{ fontSize: '0.9rem' }}
-              >
-                <FaTrash className="me-2" style={{ fontSize: '0.8rem' }} />
-                {this.state.deleteMode ? "Cancel Delete" : "Delete Mode"}
-              </Dropdown.Item>
-            </Dropdown.Menu>
-          </Dropdown>
-        </ButtonGroup>
-        
-        <small
-          className="position-absolute text-muted"
-          style={{
-            top: "-7px",
-            left: "0px",
-            backgroundColor: currentFlavour?.owner === "global" ? "#e0f2fe" : "#f1f5f9",
-            padding: "0 4px",
-            fontSize: "0.65rem",
-            zIndex: 10,
-            color: currentFlavour?.owner === "global" ? "#0369a1" : "#475569"
-          }}
-        >
-          flavour
-        </small>
-      </div>
+                      {flavourDetail.owner === "global" ? (
+                        <FaGlobe
+                          className="text-primary me-2 icon-white"
+                          style={{ fontSize: "0.8rem" }}
+                        />
+                      ) : (
+                        <FaUser
+                          className="text-secondary me-2 icon-white"
+                          style={{ fontSize: "0.8rem" }}
+                        />
+                      )}
+                      <span>{flavourDetail.flavour_name}</span>
+                    </Dropdown.Item>
+
+                    {this.state.deleteMode &&
+                      this.canDeleteFlavour(flavourDetail) && (
+                        <Button
+                          variant="link"
+                          size="sm"
+                          className="position-absolute text-danger p-0"
+                          onClick={(e) =>
+                            this.handleDeleteFlavour(
+                              flavourDetail.flavour_name,
+                              flavourDetail.owner === "global",
+                              e
+                            )
+                          }
+                          title="Delete flavour"
+                          style={{
+                            right: "12px",
+                            top: "50%",
+                            transform: "translateY(-50%)",
+                            width: "20px",
+                            height: "20px",
+                            fontSize: "0.8rem",
+                          }}
+                        >
+                          <FaTrash />
+                        </Button>
+                      )}
+                  </div>
+                ))}
+
+                <Dropdown.Divider />
+
+                <Dropdown.Item
+                  onClick={() => this.setState({ showAddFlavourModal: true })}
+                  className="text-success"
+                  style={{ fontSize: "0.9rem" }}
+                >
+                  <FaPlus className="me-2" style={{ fontSize: "0.8rem" }} />
+                  Add Flavour
+                </Dropdown.Item>
+
+                <Dropdown.Item
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    this.setState({ deleteMode: !this.state.deleteMode });
+                  }}
+                  className={
+                    this.state.deleteMode ? "text-danger" : "text-muted"
+                  }
+                  style={{ fontSize: "0.9rem" }}
+                >
+                  <FaTrash className="me-2" style={{ fontSize: "0.8rem" }} />
+                  {this.state.deleteMode ? "Cancel Delete" : "Delete Mode"}
+                </Dropdown.Item>
+              </Dropdown.Menu>
+            </Dropdown>
+          </ButtonGroup>
+
+          <small
+            className="position-absolute text-muted"
+            style={{
+              top: "-7px",
+              left: "0px",
+              backgroundColor:
+                currentFlavour?.owner === "global" ? "#e0f2fe" : "#f1f5f9",
+              padding: "0 4px",
+              fontSize: "0.65rem",
+              zIndex: 10,
+              color: currentFlavour?.owner === "global" ? "#0369a1" : "#475569",
+            }}
+          >
+            flavour
+          </small>
+        </div>
       </>
     );
   }
 
   renderDeleteConfirmModal() {
     const { flavourToDelete } = this.state;
-    
-    if (!flavourToDelete) {return null;}
+
+    if (!flavourToDelete) {
+      return null;
+    }
 
     const isGlobal = flavourToDelete.isGlobal;
     const flavourName = flavourToDelete.name;
@@ -425,15 +466,15 @@ class FlavourManager extends Component {
             Confirm Deletion
           </Modal.Title>
         </Modal.Header>
-        
+
         <Modal.Body className="pt-2">
           <div className="text-center">
             <div className="mb-3">
-              <div 
+              <div
                 className={`d-inline-flex align-items-center px-3 py-2 rounded ${
-                  isGlobal 
-                    ? 'bg-primary bg-opacity-10 border border-primary border-opacity-25' 
-                    : 'bg-secondary bg-opacity-10 border border-secondary border-opacity-25'
+                  isGlobal
+                    ? "bg-primary bg-opacity-10 border border-primary border-opacity-25"
+                    : "bg-secondary bg-opacity-10 border border-secondary border-opacity-25"
                 }`}
               >
                 {isGlobal ? (
@@ -443,15 +484,15 @@ class FlavourManager extends Component {
                 )}
                 <strong>{flavourName}</strong>
                 <small className="ms-2 text-muted">
-                  ({isGlobal ? 'Global' : 'Personal'})
+                  ({isGlobal ? "Global" : "Personal"})
                 </small>
               </div>
             </div>
-            
+
             <p className="mb-0">
               Are you sure you want to delete this flavour?
             </p>
-            
+
             {isGlobal && (
               <Alert variant="warning" className="mt-3 mb-0 small">
                 <FaExclamationTriangle className="me-1" />
@@ -460,17 +501,17 @@ class FlavourManager extends Component {
             )}
           </div>
         </Modal.Body>
-        
+
         <Modal.Footer className="border-0 pt-0">
-          <Button 
-            variant="outline-secondary" 
+          <Button
+            variant="outline-secondary"
             onClick={this.cancelDeleteFlavour}
             className="px-4"
           >
             Cancel
           </Button>
-          <Button 
-            variant="danger" 
+          <Button
+            variant="danger"
             onClick={this.confirmDeleteFlavour}
             className="px-4"
           >
@@ -513,38 +554,39 @@ class FlavourManager extends Component {
       }
     };
 
-    if (!this.state.showAddFlavourModal) { return null; }
+    if (!this.state.showAddFlavourModal) {
+      return null;
+    }
     // TODO: all header and style of the modal comes from
-    // token modal. we might change the naming on the 
+    // token modal. we might change the naming on the
     // token modal to shared or something else to be able to
     // reuse the modal styling
     return (
-      <div 
-        className="token-modal show"
-        onClick={handleBackdropClick}
-      >
-        <div 
-          className="token-modal-content" 
-            style={{ 
-            maxHeight: '90vh', 
-            display: 'flex', 
-            flexDirection: 'column' 
+      <div className="token-modal show" onClick={handleBackdropClick}>
+        <div
+          className="token-modal-content"
+          style={{
+            maxHeight: "90vh",
+            display: "flex",
+            flexDirection: "column",
           }}
         >
           <div
             className="token-header"
-            style={{ 
+            style={{
               flexShrink: 0,
-              borderBottom: '1px solid #e2e8f0'
+              borderBottom: "1px solid #e2e8f0",
             }}
           >
             <h1>
-              <FaPlus className="me-2" style={{ fontSize: '18px' }} />
+              <FaPlus className="me-2" style={{ fontSize: "18px" }} />
               Flavour Management
             </h1>
-            <p>Create and manage data flavours for customized search experiences</p>
-            <button 
-              className="token-close-btn" 
+            <p>
+              Create and manage data flavours for customized search experiences
+            </p>
+            <button
+              className="token-close-btn"
               onClick={() => this.setState({ showAddFlavourModal: false })}
             >
               ×
@@ -553,31 +595,33 @@ class FlavourManager extends Component {
 
           <div
             className="token-section"
-            style={{ 
-              flex: 1, 
-              overflowY: 'auto', 
-              padding: '20px',
-              maxHeight: 'calc(90vh - 160px)'
+            style={{
+              flex: 1,
+              overflowY: "auto",
+              padding: "20px",
+              maxHeight: "calc(90vh - 160px)",
             }}
           >
             {/* Error Alert */}
             {this.state.modalError && (
-              <div style={{
-                position: 'sticky',
-                top: '-20px',
-                zIndex: 100,
-                marginBottom: '20px'
-              }}>
+              <div
+                style={{
+                  position: "sticky",
+                  top: "-20px",
+                  zIndex: 100,
+                  marginBottom: "20px",
+                }}
+              >
                 <Alert
                   variant="danger"
                   className="mb-0"
-                  style={{ 
-                    borderRadius: '8px', 
-                    border: 'none', 
-                    backgroundColor: '#fecaca',
-                    color: '#991b1b',
-                    fontSize: '14px',
-                    boxShadow: '0 4px 12px rgba(239, 68, 68, 0.15)'
+                  style={{
+                    borderRadius: "8px",
+                    border: "none",
+                    backgroundColor: "#fecaca",
+                    color: "#991b1b",
+                    fontSize: "14px",
+                    boxShadow: "0 4px 12px rgba(239, 68, 68, 0.15)",
                   }}
                 >
                   {this.state.modalError}
@@ -588,142 +632,188 @@ class FlavourManager extends Component {
             {/* Add Flavour Form */}
             <div>
               <div className="token-status mb-3">
-                <div className="token-label" style={{ fontSize: '18px' }}>Add New Flavour:</div>
+                <div className="token-label" style={{ fontSize: "18px" }}>
+                  Add New Flavour:
+                </div>
               </div>
-              
+
               <Form onSubmit={this.handleAddFlavour}>
                 {/* Toggle and Flavour Row */}
                 <Row className="mb-3">
                   <Col md={12}>
-                    <div style={{ display: 'flex', alignItems: 'flex-start', gap: '16px' }}>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "flex-start",
+                        gap: "16px",
+                      }}
+                    >
                       {/* Toggle on Left */}
-                      <div style={{ 
-                        display: 'flex', 
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        minWidth: '100px',
-                        maxWidth: '100px'
-                      }}>
+                      <div
+                        style={{
+                          display: "flex",
+                          flexDirection: "column",
+                          alignItems: "center",
+                          minWidth: "100px",
+                          maxWidth: "100px",
+                        }}
+                      >
                         <div
-                            style={{ 
-                            display: 'flex', 
-                            flexDirection: 'column',
-                            alignItems: 'center', 
-                            gap: '6px',
-                            padding: '10px',
-                            background: this.state.isGlobal ? '#f0f9ff' : '#f8fafc',
-                            border: `2px solid ${this.state.isGlobal ? '#0ea5e9' : '#e2e8f0'}`,
-                            borderRadius: '10px',
-                            transition: 'all 0.3s ease',
-                            cursor: 'pointer'
+                          style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            alignItems: "center",
+                            gap: "6px",
+                            padding: "10px",
+                            background: this.state.isGlobal
+                              ? "#f0f9ff"
+                              : "#f8fafc",
+                            border: `2px solid ${this.state.isGlobal ? "#0ea5e9" : "#e2e8f0"}`,
+                            borderRadius: "10px",
+                            transition: "all 0.3s ease",
+                            cursor: "pointer",
                           }}
-                          onClick={() => this.setState({ isGlobal: !this.state.isGlobal })}
+                          onClick={() =>
+                            this.setState({ isGlobal: !this.state.isGlobal })
+                          }
                         >
                           {/* Toggle Icon Display */}
-                          <div style={{
-                            width: '24px',
-                            height: '24px',
-                            background: this.state.isGlobal ? '#0ea5e9' : '#6b7280',
-                            borderRadius: '50%',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            transition: 'all 0.3s ease'
-                          }}>
+                          <div
+                            style={{
+                              width: "24px",
+                              height: "24px",
+                              background: this.state.isGlobal
+                                ? "#0ea5e9"
+                                : "#6b7280",
+                              borderRadius: "50%",
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              transition: "all 0.3s ease",
+                            }}
+                          >
                             {this.state.isGlobal ? (
-                              <FaGlobe style={{ 
-                                fontSize: '12px', 
-                                color: 'white' 
-                              }} />
+                              <FaGlobe
+                                style={{
+                                  fontSize: "12px",
+                                  color: "white",
+                                }}
+                              />
                             ) : (
-                              <FaUser style={{ 
-                                fontSize: '12px', 
-                                color: 'white' 
-                              }} />
+                              <FaUser
+                                style={{
+                                  fontSize: "12px",
+                                  color: "white",
+                                }}
+                              />
                             )}
                           </div>
-                          
+
                           {/* Toggle Text */}
-                          <span style={{ 
-                            fontSize: '11px', 
-                            fontWeight: '600',
-                            color: this.state.isGlobal ? '#0ea5e9' : '#6b7280',
-                            textAlign: 'center'
-                          }}>
-                            {this.state.isGlobal ? 'Global' : 'Personal'}
+                          <span
+                            style={{
+                              fontSize: "11px",
+                              fontWeight: "600",
+                              color: this.state.isGlobal
+                                ? "#0ea5e9"
+                                : "#6b7280",
+                              textAlign: "center",
+                            }}
+                          >
+                            {this.state.isGlobal ? "Global" : "Personal"}
                           </span>
-                          
+
                           {/* Toggle Switch */}
-                          <div style={{
-                            width: '36px',
-                            height: '20px',
-                            background: this.state.isGlobal ? '#0ea5e9' : '#cbd5e1',
-                            borderRadius: '10px',
-                            position: 'relative',
-                            transition: 'all 0.3s ease',
-                            boxShadow: 'inset 0 1px 3px rgba(0,0,0,0.1)'
-                          }}>
-                            <div style={{
-                              width: '16px',
-                              height: '16px',
-                              background: 'white',
-                              borderRadius: '50%',
-                              position: 'absolute',
-                              top: '2px',
-                              left: this.state.isGlobal ? '18px' : '2px',
-                              transition: 'all 0.3s ease',
-                              boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
-                              display: 'flex',
-                              alignItems: 'center',
-                              justifyContent: 'center'
-                            }}>
+                          <div
+                            style={{
+                              width: "36px",
+                              height: "20px",
+                              background: this.state.isGlobal
+                                ? "#0ea5e9"
+                                : "#cbd5e1",
+                              borderRadius: "10px",
+                              position: "relative",
+                              transition: "all 0.3s ease",
+                              boxShadow: "inset 0 1px 3px rgba(0,0,0,0.1)",
+                            }}
+                          >
+                            <div
+                              style={{
+                                width: "16px",
+                                height: "16px",
+                                background: "white",
+                                borderRadius: "50%",
+                                position: "absolute",
+                                top: "2px",
+                                left: this.state.isGlobal ? "18px" : "2px",
+                                transition: "all 0.3s ease",
+                                boxShadow: "0 1px 3px rgba(0,0,0,0.2)",
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                              }}
+                            >
                               {this.state.isGlobal ? (
-                                <FaGlobe style={{ 
-                                  fontSize: '8px', 
-                                  color: '#0ea5e9' 
-                                }} />
+                                <FaGlobe
+                                  style={{
+                                    fontSize: "8px",
+                                    color: "#0ea5e9",
+                                  }}
+                                />
                               ) : (
-                                <FaUser style={{ 
-                                  fontSize: '8px', 
-                                  color: '#6b7280' 
-                                }} />
+                                <FaUser
+                                  style={{
+                                    fontSize: "8px",
+                                    color: "#6b7280",
+                                  }}
+                                />
                               )}
                             </div>
                           </div>
                         </div>
                       </div>
-                      
+
                       {/* Flavour Input */}
                       <div style={{ flex: 1 }}>
                         <Form.Group>
-                          <Form.Label style={{ fontWeight: '600', color: '#1e293b', fontSize: '14px', marginBottom: '6px' }}>
+                          <Form.Label
+                            style={{
+                              fontWeight: "600",
+                              color: "#1e293b",
+                              fontSize: "14px",
+                              marginBottom: "6px",
+                            }}
+                          >
                             Flavour Name
                           </Form.Label>
                           <Form.Control
                             type="text"
                             value={this.state.flavourName}
-                            onChange={(e) => this.setState({ flavourName: e.target.value })}
+                            onChange={(e) =>
+                              this.setState({ flavourName: e.target.value })
+                            }
                             placeholder="e.g., nextgem, custom_project"
                             style={{
-                              border: '2px solid #e2e8f0',
-                              borderRadius: '6px',
-                              padding: '10px 12px',
-                              fontSize: '14px'
+                              border: "2px solid #e2e8f0",
+                              borderRadius: "6px",
+                              padding: "10px 12px",
+                              fontSize: "14px",
                             }}
                             required
                           />
 
                           {/* Toggle Helper text */}
-                          <div style={{ 
-                            fontSize: '11px', 
-                            color: '#6b7280', 
-                            marginTop: '4px',
-                            fontStyle: 'italic'
-                          }}>
-                            {this.state.isGlobal 
-                              ? " Available to all users (requires admin permissions)" 
-                              : " Personal flavour"
-                            }
+                          <div
+                            style={{
+                              fontSize: "11px",
+                              color: "#6b7280",
+                              marginTop: "4px",
+                              fontStyle: "italic",
+                            }}
+                          >
+                            {this.state.isGlobal
+                              ? " Available to all users (requires admin permissions)"
+                              : " Personal flavour"}
                           </div>
                         </Form.Group>
                       </div>
@@ -732,54 +822,74 @@ class FlavourManager extends Component {
                 </Row>
 
                 <Form.Group className="mb-3">
-                  <Form.Label style={{ fontWeight: '600', color: '#1e293b', fontSize: '14px' }}>
+                  <Form.Label
+                    style={{
+                      fontWeight: "600",
+                      color: "#1e293b",
+                      fontSize: "14px",
+                    }}
+                  >
                     Facet Mappings
                   </Form.Label>
-                  <div style={{
-                    background: '#f8fafc',
-                    border: '2px solid #e2e8f0',
-                    borderRadius: '8px',
-                    padding: '12px'
-                  }}>
-
+                  <div
+                    style={{
+                      background: "#f8fafc",
+                      border: "2px solid #e2e8f0",
+                      borderRadius: "8px",
+                      padding: "12px",
+                    }}
+                  >
                     <Row>
                       {availableFacets.map((facet) => (
                         <Col md={4} key={facet.key} className="mb-2">
                           <Form.Group>
-                            <Form.Label style={{ fontSize: '11px', color: '#6b7280', marginBottom: '4px', fontWeight: '500' }}>
+                            <Form.Label
+                              style={{
+                                fontSize: "11px",
+                                color: "#6b7280",
+                                marginBottom: "4px",
+                                fontWeight: "500",
+                              }}
+                            >
                               {facet.label}
                             </Form.Label>
                             <Form.Control
                               type="text"
                               value={this.state.facetMappings[facet.key]}
-                              onChange={(e) => this.setState({
-                                facetMappings: {
-                                  ...this.state.facetMappings,
-                                  [facet.key]: e.target.value
-                                }
-                              })}
+                              onChange={(e) =>
+                                this.setState({
+                                  facetMappings: {
+                                    ...this.state.facetMappings,
+                                    [facet.key]: e.target.value,
+                                  },
+                                })
+                              }
                               placeholder={`Map ${facet.label.toLowerCase()}`}
                               style={{
-                                fontSize: '12px',
-                                padding: '6px 8px',
-                                border: '1px solid #e2e8f0',
-                                borderRadius: '4px'
+                                fontSize: "12px",
+                                padding: "6px 8px",
+                                border: "1px solid #e2e8f0",
+                                borderRadius: "4px",
                               }}
                             />
                           </Form.Group>
                         </Col>
                       ))}
                     </Row>
-                    <div style={{
-                      fontSize: '11px',
-                      color: '#6b7280',
-                      fontStyle: 'italic',
-                      marginTop: '8px',
-                      padding: '6px',
-                      background: 'white',
-                      borderRadius: '4px'
-                    }}>
-                      <strong>Example:</strong> For CMIP6 data, you might map &quot;project&quot; to &quot;mip_era&quot;, &quot;model&quot; to &quot;source_id&quot;, etc.
+                    <div
+                      style={{
+                        fontSize: "11px",
+                        color: "#6b7280",
+                        fontStyle: "italic",
+                        marginTop: "8px",
+                        padding: "6px",
+                        background: "white",
+                        borderRadius: "4px",
+                      }}
+                    >
+                      <strong>Example:</strong> For CMIP6 data, you might map
+                      &quot;project&quot; to &quot;mip_era&quot;,
+                      &quot;model&quot; to &quot;source_id&quot;, etc.
                     </div>
                   </div>
                 </Form.Group>
@@ -788,54 +898,58 @@ class FlavourManager extends Component {
           </div>
 
           {/* Add Flavour Footer Buttons */}
-          <div style={{
-            flexShrink: 0,
-            padding: '16px 20px',
-            borderTop: '1px solid #e2e8f0',
-            background: 'white',
-            borderRadius: '0 0 12px 12px'
-          }}>
+          <div
+            style={{
+              flexShrink: 0,
+              padding: "16px 20px",
+              borderTop: "1px solid #e2e8f0",
+              background: "white",
+              borderRadius: "0 0 12px 12px",
+            }}
+          >
             <div className="token-actions" style={{ margin: 0 }}>
-              <button 
+              <button
                 type="button"
                 className="token-btn"
                 onClick={() => this.setState({ showAddFlavourModal: false })}
-                style={{ 
-                  background: '#6b7280',
-                  fontSize: '14px',
-                  padding: '10px 16px'
+                style={{
+                  background: "#6b7280",
+                  fontSize: "14px",
+                  padding: "10px 16px",
                 }}
               >
                 Cancel
               </button>
-              <button 
-                type="submit" 
+              <button
+                type="submit"
                 className="token-btn"
                 disabled={this.state.modalLoading}
                 onClick={this.handleAddFlavour}
-                style={{ 
+                style={{
                   opacity: this.state.modalLoading ? 0.6 : 1,
-                  cursor: this.state.modalLoading ? 'not-allowed' : 'pointer',
-                  fontSize: '14px',
-                  padding: '10px 16px'
+                  cursor: this.state.modalLoading ? "not-allowed" : "pointer",
+                  fontSize: "14px",
+                  padding: "10px 16px",
                 }}
               >
                 {this.state.modalLoading ? (
                   <>
-                    <div style={{
-                      border: '2px solid #f3f4f6',
-                      borderTop: '2px solid white',
-                      borderRadius: '50%',
-                      width: '14px',
-                      height: '14px',
-                      animation: 'spin 1s linear infinite',
-                      marginRight: '6px'
-                    }} />
+                    <div
+                      style={{
+                        border: "2px solid #f3f4f6",
+                        borderTop: "2px solid white",
+                        borderRadius: "50%",
+                        width: "14px",
+                        height: "14px",
+                        animation: "spin 1s linear infinite",
+                        marginRight: "6px",
+                      }}
+                    />
                     Adding...
                   </>
                 ) : (
                   <>
-                    <FaPlus style={{ fontSize: '12px' }} />
+                    <FaPlus style={{ fontSize: "12px" }} />
                     Add Flavour
                   </>
                 )}
@@ -861,8 +975,9 @@ class FlavourManager extends Component {
             onClose={() => this.setState({ showToast: false })}
             show={this.state.showToast}
             delay={3000}
-            style={{ 
-              backgroundColor: this.state.toastVariant === "success" ? "#ddede5" : "#f8d7da" 
+            style={{
+              backgroundColor:
+                this.state.toastVariant === "success" ? "#ddede5" : "#f8d7da",
             }}
             autohide
           >

--- a/assets/js/Containers/Databrowser/FlavourManager.js
+++ b/assets/js/Containers/Databrowser/FlavourManager.js
@@ -19,6 +19,8 @@ import {
   FaExclamationTriangle,
 } from "react-icons/fa";
 
+import { AVAILABLE_FACETS } from "./constants";
+
 class FlavourManager extends Component {
   constructor(props) {
     super(props);
@@ -31,29 +33,9 @@ class FlavourManager extends Component {
       flavourToDelete: null,
       // IMPORTANR: Modal form state; in case, if we added new facets, we need to re-construct the form
       flavourName: "",
-      facetMappings: {
-        project: "",
-        model: "",
-        experiment: "",
-        variable: "",
-        institute: "",
-        time_frequency: "",
-        cmor_table: "",
-        ensemble: "",
-        fs_type: "",
-        grid_label: "",
-        product: "",
-        realm: "",
-        time_aggregation: "",
-        dataset: "",
-        driving_model: "",
-        format: "",
-        grid_id: "",
-        level_type: "",
-        rcm_name: "",
-        rcm_version: "",
-        user: "",
-      },
+      facetMappings: Object.fromEntries(
+        AVAILABLE_FACETS.map((facet) => [facet.key, ""])
+      ),
       isGlobal: false,
       modalError: "",
       modalLoading: false,
@@ -108,29 +90,9 @@ class FlavourManager extends Component {
       // Reset the form on success and close the modal
       this.setState({
         flavourName: "",
-        facetMappings: {
-          project: "",
-          model: "",
-          experiment: "",
-          variable: "",
-          institute: "",
-          time_frequency: "",
-          cmor_table: "",
-          ensemble: "",
-          fs_type: "",
-          grid_label: "",
-          product: "",
-          realm: "",
-          time_aggregation: "",
-          dataset: "",
-          driving_model: "",
-          format: "",
-          grid_id: "",
-          level_type: "",
-          rcm_name: "",
-          rcm_version: "",
-          user: "",
-        },
+        facetMappings: Object.fromEntries(
+          AVAILABLE_FACETS.map((facet) => [facet.key, ""])
+        ),
         isGlobal: false,
         modalError: "",
         showAddFlavourModal: false,
@@ -230,15 +192,7 @@ class FlavourManager extends Component {
       return false;
     }
 
-    const currentUser = this.props.currentUser || "unknown";
-    const isAdmin = this.props.isAdmin || false;
-
-    return (
-      flavour.owner === currentUser ||
-      (isAdmin && flavour.owner === "global") ||
-      flavour.owner === "global" ||
-      flavour.owner !== "global"
-    );
+    return true;
   }
 
   canAddFlavour() {
@@ -524,30 +478,6 @@ class FlavourManager extends Component {
   }
 
   renderAddFlavourModal() {
-    const availableFacets = [
-      { key: "project", label: "Project" },
-      { key: "model", label: "Model" },
-      { key: "experiment", label: "Experiment" },
-      { key: "variable", label: "Variable" },
-      { key: "institute", label: "Institute" },
-      { key: "time_frequency", label: "Time Frequency" },
-      { key: "cmor_table", label: "CMOR Table" },
-      { key: "ensemble", label: "Ensemble" },
-      { key: "fs_type", label: "File System Type" },
-      { key: "grid_label", label: "Grid Label" },
-      { key: "product", label: "Product" },
-      { key: "realm", label: "Realm" },
-      { key: "time_aggregation", label: "Time Aggregation" },
-      { key: "dataset", label: "Dataset" },
-      { key: "driving_model", label: "Driving Model" },
-      { key: "format", label: "Format" },
-      { key: "grid_id", label: "Grid ID" },
-      { key: "level_type", label: "Level Type" },
-      { key: "rcm_name", label: "RCM Name" },
-      { key: "rcm_version", label: "RCM Version" },
-      { key: "user", label: "User" },
-    ];
-
     const handleBackdropClick = (e) => {
       if (e.target === e.currentTarget) {
         this.setState({ showAddFlavourModal: false });
@@ -840,7 +770,7 @@ class FlavourManager extends Component {
                     }}
                   >
                     <Row>
-                      {availableFacets.map((facet) => (
+                      {AVAILABLE_FACETS.map((facet) => (
                         <Col md={4} key={facet.key} className="mb-2">
                           <Form.Group>
                             <Form.Label

--- a/assets/js/Containers/Databrowser/FlavourManager.js
+++ b/assets/js/Containers/Databrowser/FlavourManager.js
@@ -1,0 +1,891 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import {
+  Button,
+  Alert,
+  Form,
+  Dropdown,
+  ButtonGroup,
+  Toast,
+  Modal,
+  Row,
+  Col,
+} from "react-bootstrap";
+import {
+  FaGlobe,
+  FaUser,
+  FaTrash,
+  FaPlus,
+  FaExclamationTriangle,
+} from "react-icons/fa";
+
+class FlavourManager extends Component {
+  constructor(props) {
+    super(props);
+    
+    this.state = {
+      additionalFacetsVisible: false,
+      showAddFlavourModal: false,
+      deleteMode: false,
+      showDeleteConfirmModal: false,
+      flavourToDelete: null,
+      // IMPORTANR: Modal form state; in case, if we added new facets, we need to re-construct the form
+      flavourName: "",
+      facetMappings: {
+        project: "",
+        model: "",
+        experiment: "",
+        variable: "",
+        institute: "",
+        time_frequency: "",
+        cmor_table: "",
+        ensemble: "",
+        fs_type: "",
+        grid_label: "",
+        product: "",
+        realm: "",
+        time_aggregation: "",
+        dataset: "",
+        driving_model: "",
+        format: "",
+        grid_id: "",
+        level_type: "",
+        rcm_name: "",
+        rcm_version: "",
+        user: "",
+      },
+      isGlobal: false,
+      modalError: "",
+      modalLoading: false,
+      showToast: false,
+      toastMessage: "",
+      toastVariant: "success",
+    };
+
+    this.handleAddFlavour = this.handleAddFlavour.bind(this);
+    this.handleDeleteFlavour = this.handleDeleteFlavour.bind(this);
+  }
+
+  showToast(message, variant = "success") {
+    this.setState({
+      showToast: true,
+      toastMessage: message,
+      toastVariant: variant,
+    });
+    setTimeout(() => this.setState({ showToast: false }), 3000);
+  }
+
+  async handleAddFlavour(e) {
+    e.preventDefault();
+    if (!this.state.flavourName.trim()) {
+      this.setState({ modalError: "Flavour name is required" });
+      return;
+    }
+    
+    // Building the mapping from user-input form data
+    const mapping = {};
+    Object.entries(this.state.facetMappings).forEach(([key, value]) => {
+      if (value.trim()) {
+        mapping[key] = value.trim();
+      }
+    });
+
+    if (Object.keys(mapping).length === 0) {
+      this.setState({ modalError: "At least one facet mapping is required" });
+      return;
+    }
+
+    this.setState({ modalLoading: true });
+    try {
+      await this.props.dispatch(this.props.addFlavour({
+        flavour_name: this.state.flavourName,
+        mapping,
+        is_global: this.state.isGlobal
+      }));
+      
+      // Reset the form on success and close the modal
+      this.setState({ 
+        flavourName: "", 
+        facetMappings: {
+          project: "",
+          model: "",
+          experiment: "",
+          variable: "",
+          institute: "",
+          time_frequency: "",
+          cmor_table: "",
+          ensemble: "",
+          fs_type: "",
+          grid_label: "",
+          product: "",
+          realm: "",
+          time_aggregation: "",
+          dataset: "",
+          driving_model: "",
+          format: "",
+          grid_id: "",
+          level_type: "",
+          rcm_name: "",
+          rcm_version: "",
+          user: "",
+        },
+        isGlobal: false, 
+        modalError: "",
+        showAddFlavourModal: false 
+      });
+      
+      this.showToast("Flavour added successfully!", "success");
+    } catch (err) {
+      const canAdd = this.canAddFlavour();
+      const message = canAdd ? 
+        (err.message || "Failed to add flavour") : 
+        "You don't have permission to add flavours";
+      this.setState({ modalError: message });
+      this.showToast(message, "danger");
+    } finally {
+      this.setState({ modalLoading: false });
+    }
+  }
+
+  handleDeleteFlavour(flavourName, isGlobal, event = null) {
+    if (event) {
+      event.stopPropagation();
+    }
+    
+    // TODO: we need to still think if window.confirm is better here
+    // or we need to use a modal
+    this.setState({
+      showDeleteConfirmModal: true,
+      flavourToDelete: { name: flavourName, isGlobal }
+    });
+  }
+
+  confirmDeleteFlavour = () => {
+    if (this.state.flavourToDelete) {
+      this.performDeleteFlavour(
+        this.state.flavourToDelete.name, 
+        this.state.flavourToDelete.isGlobal
+      );
+    }
+    this.setState({ 
+      showDeleteConfirmModal: false, 
+      flavourToDelete: null 
+    });
+  }
+
+  cancelDeleteFlavour = () => {
+    this.setState({ 
+      showDeleteConfirmModal: false, 
+      flavourToDelete: null 
+    });
+  }
+
+  async performDeleteFlavour(flavourName, isGlobal) {
+    try {
+      await this.props.dispatch(this.props.deleteFlavour(flavourName, isGlobal));
+      
+      // IMPORTANT: If the flavour being deleted is the current one, reset to default
+      // to `freva`
+      const currentFlavour = this.props.currentFlavour || this.props.defaultFlavour;
+      if (currentFlavour === flavourName) {
+        this.props.onFlavourClick("freva");
+      }
+      
+      this.showToast("Flavour deleted successfully!", "success");
+    } catch (err) {
+      const canDelete = this.canDeleteFlavour({ 
+        flavour_name: flavourName, 
+        owner: isGlobal ? "global" : "user" 
+      });
+      
+      let message;
+      if (!canDelete) {
+        if (isGlobal) {
+          message = "Only administrators can delete global flavours";
+        } else {
+          message = "You don't have permission to delete this flavour";
+        }
+      } else {
+        // To keep the code clean, we shown the API web service message if available
+        const serverMessage = err.message || "";
+        if (serverMessage.toLowerCase().includes("create")) {
+          message = "Failed to delete flavour - insufficient permissions";
+        } else {
+          message = serverMessage || "Failed to delete flavour";
+        }
+      }
+      
+      this.showToast(message, "danger");
+    }
+  }
+
+  canDeleteFlavour(flavour) {
+    const builtInFlavours = ["freva", "cmip5", "cmip6", "cordex", "user"];
+    if (builtInFlavours.includes(flavour.flavour_name.toLowerCase())) {
+      return false;
+    }
+    
+    const currentUser = this.props.currentUser || "unknown";
+    const isAdmin = this.props.isAdmin || false;
+    
+    return flavour.owner === currentUser || 
+           (isAdmin && flavour.owner === "global") ||
+           flavour.owner === "global" || flavour.owner !== "global";
+  }
+
+  canAddFlavour() {
+    // TODO: For now, we allow everyone to try adding flavours
+    // The server will handle the actual permission check.
+    // we might in the future want to restrict this to admins only
+    return true;
+  }
+
+  getSortedFlavours() {
+    // NOte: always global flavours are sorted first and then 
+    // user flavours
+    const { flavourDetails } = this.props;
+    if (!flavourDetails) {return []}
+    
+    return [...flavourDetails].sort((a, b) => {
+      if (a.owner === "global" && b.owner !== "global") {return -1}
+      if (a.owner !== "global" && b.owner === "global") {return 1}
+      return a.flavour_name.localeCompare(b.flavour_name);
+    });
+  }
+
+  renderFlavourDropdown() {
+    const sortedFlavours = this.getSortedFlavours();
+    const flavour = this.props.currentFlavour || this.props.defaultFlavour;
+    const currentFlavour = sortedFlavours.find(f => f.flavour_name === flavour);
+  
+    return (
+      <>
+        <style>{`
+          .custom-dropdown-item.active .icon-white {
+            color: white !important;
+          }
+          .dropdown-toggle-custom:hover {
+            opacity: 0.9 !important;
+            transform: translateY(-1px);
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1) !important;
+          }
+          .dropdown-toggle-custom:focus {
+            box-shadow: 0 0 0 0.2rem rgba(3, 105, 161, 0.25) !important;
+          }
+        `}</style>
+        
+        <div className="position-relative me-1">
+        <ButtonGroup>
+          <Dropdown 
+            onToggle={(isOpen) => {
+              if (!isOpen) {
+                this.setState({ deleteMode: false });
+              }
+            }}
+          >
+            <Dropdown.Toggle 
+              variant="outline-secondary" 
+              id="flavour-dropdown"
+              className="d-flex align-items-center dropdown-toggle-custom"
+              style={{
+                minWidth: '120px',
+                fontSize: '0.9rem'
+              }}
+            >
+              <div className="d-flex align-items-center w-100">
+                {currentFlavour?.owner === "global" ? (
+                  <FaGlobe
+                    className="me-2"
+                    style={{ 
+                      fontSize: '0.8rem', 
+                      color: '#0369a1' 
+                    }} 
+                  />
+                ) : (
+                  <FaUser
+                    className="me-2" 
+                    style={{ 
+                      fontSize: '0.8rem', 
+                      color: '#475569' 
+                    }} 
+                  />
+                )}
+                <span className="text-truncate">{flavour}</span>
+              </div>
+            </Dropdown.Toggle>
+  
+            <Dropdown.Menu
+              style={{ minWidth: '160px' }}
+            >
+              {sortedFlavours.map((flavourDetail) => (
+                <div key={flavourDetail.flavour_name} className="position-relative">
+                  <Dropdown.Item
+                    active={flavour === flavourDetail.flavour_name}
+                    onClick={() => this.props.onFlavourClick(flavourDetail.flavour_name)}
+                    className="d-flex align-items-center custom-dropdown-item"
+                    style={{ 
+                      paddingRight: this.state.deleteMode && this.canDeleteFlavour(flavourDetail) ? '50px' : '16px',
+                      fontSize: '0.9rem'
+                    }}
+                  >
+                    {flavourDetail.owner === "global" ? (
+                      <FaGlobe className="text-primary me-2 icon-white" style={{ fontSize: '0.8rem' }} />
+                    ) : (
+                      <FaUser className="text-secondary me-2 icon-white" style={{ fontSize: '0.8rem' }} />
+                    )}
+                    <span>{flavourDetail.flavour_name}</span>
+                  </Dropdown.Item>
+                  
+                  {this.state.deleteMode && this.canDeleteFlavour(flavourDetail) && (
+                    <Button
+                      variant="link"
+                      size="sm"
+                      className="position-absolute text-danger p-0"
+                      onClick={(e) => this.handleDeleteFlavour(flavourDetail.flavour_name, flavourDetail.owner === "global", e)}
+                      title="Delete flavour"
+                      style={{
+                        right: '12px',
+                        top: '50%',
+                        transform: 'translateY(-50%)',
+                        width: '20px',
+                        height: '20px',
+                        fontSize: '0.8rem'
+                      }}
+                    >
+                      <FaTrash />
+                    </Button>
+                  )}
+                </div>
+              ))}
+              
+              <Dropdown.Divider />
+              
+              <Dropdown.Item 
+                onClick={() => this.setState({ showAddFlavourModal: true })}
+                className="text-success"
+                style={{ fontSize: '0.9rem' }}
+              >
+                <FaPlus className="me-2" style={{ fontSize: '0.8rem' }} />
+                Add Flavour
+              </Dropdown.Item>
+              
+              <Dropdown.Item 
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  this.setState({ deleteMode: !this.state.deleteMode });
+                }}
+                className={this.state.deleteMode ? "text-danger" : "text-muted"}
+                style={{ fontSize: '0.9rem' }}
+              >
+                <FaTrash className="me-2" style={{ fontSize: '0.8rem' }} />
+                {this.state.deleteMode ? "Cancel Delete" : "Delete Mode"}
+              </Dropdown.Item>
+            </Dropdown.Menu>
+          </Dropdown>
+        </ButtonGroup>
+        
+        <small
+          className="position-absolute text-muted"
+          style={{
+            top: "-7px",
+            left: "0px",
+            backgroundColor: currentFlavour?.owner === "global" ? "#e0f2fe" : "#f1f5f9",
+            padding: "0 4px",
+            fontSize: "0.65rem",
+            zIndex: 10,
+            color: currentFlavour?.owner === "global" ? "#0369a1" : "#475569"
+          }}
+        >
+          flavour
+        </small>
+      </div>
+      </>
+    );
+  }
+
+  renderDeleteConfirmModal() {
+    const { flavourToDelete } = this.state;
+    
+    if (!flavourToDelete) {return null;}
+
+    const isGlobal = flavourToDelete.isGlobal;
+    const flavourName = flavourToDelete.name;
+
+    return (
+      <Modal
+        show={this.state.showDeleteConfirmModal}
+        onHide={this.cancelDeleteFlavour}
+        centered
+        backdrop="static"
+      >
+        <Modal.Header closeButton className="border-0 pb-0">
+          <Modal.Title className="d-flex align-items-center text-danger">
+            <FaExclamationTriangle className="me-2" />
+            Confirm Deletion
+          </Modal.Title>
+        </Modal.Header>
+        
+        <Modal.Body className="pt-2">
+          <div className="text-center">
+            <div className="mb-3">
+              <div 
+                className={`d-inline-flex align-items-center px-3 py-2 rounded ${
+                  isGlobal 
+                    ? 'bg-primary bg-opacity-10 border border-primary border-opacity-25' 
+                    : 'bg-secondary bg-opacity-10 border border-secondary border-opacity-25'
+                }`}
+              >
+                {isGlobal ? (
+                  <FaGlobe className="text-primary me-2" />
+                ) : (
+                  <FaUser className="text-secondary me-2" />
+                )}
+                <strong>{flavourName}</strong>
+                <small className="ms-2 text-muted">
+                  ({isGlobal ? 'Global' : 'Personal'})
+                </small>
+              </div>
+            </div>
+            
+            <p className="mb-0">
+              Are you sure you want to delete this flavour?
+            </p>
+            
+            {isGlobal && (
+              <Alert variant="warning" className="mt-3 mb-0 small">
+                <FaExclamationTriangle className="me-1" />
+                This is a global flavour that affects all users!
+              </Alert>
+            )}
+          </div>
+        </Modal.Body>
+        
+        <Modal.Footer className="border-0 pt-0">
+          <Button 
+            variant="outline-secondary" 
+            onClick={this.cancelDeleteFlavour}
+            className="px-4"
+          >
+            Cancel
+          </Button>
+          <Button 
+            variant="danger" 
+            onClick={this.confirmDeleteFlavour}
+            className="px-4"
+          >
+            <FaTrash className="me-1" />
+            Delete
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+
+  renderAddFlavourModal() {
+    const availableFacets = [
+      { key: "project", label: "Project" },
+      { key: "model", label: "Model" },
+      { key: "experiment", label: "Experiment" },
+      { key: "variable", label: "Variable" },
+      { key: "institute", label: "Institute" },
+      { key: "time_frequency", label: "Time Frequency" },
+      { key: "cmor_table", label: "CMOR Table" },
+      { key: "ensemble", label: "Ensemble" },
+      { key: "fs_type", label: "File System Type" },
+      { key: "grid_label", label: "Grid Label" },
+      { key: "product", label: "Product" },
+      { key: "realm", label: "Realm" },
+      { key: "time_aggregation", label: "Time Aggregation" },
+      { key: "dataset", label: "Dataset" },
+      { key: "driving_model", label: "Driving Model" },
+      { key: "format", label: "Format" },
+      { key: "grid_id", label: "Grid ID" },
+      { key: "level_type", label: "Level Type" },
+      { key: "rcm_name", label: "RCM Name" },
+      { key: "rcm_version", label: "RCM Version" },
+      { key: "user", label: "User" },
+    ];
+
+    const handleBackdropClick = (e) => {
+      if (e.target === e.currentTarget) {
+        this.setState({ showAddFlavourModal: false });
+      }
+    };
+
+    if (!this.state.showAddFlavourModal) { return null; }
+    // TODO: all header and style of the modal comes from
+    // token modal. we might change the naming on the 
+    // token modal to shared or something else to be able to
+    // reuse the modal styling
+    return (
+      <div 
+        className="token-modal show"
+        onClick={handleBackdropClick}
+      >
+        <div 
+          className="token-modal-content" 
+            style={{ 
+            maxHeight: '90vh', 
+            display: 'flex', 
+            flexDirection: 'column' 
+          }}
+        >
+          <div
+            className="token-header"
+            style={{ 
+              flexShrink: 0,
+              borderBottom: '1px solid #e2e8f0'
+            }}
+          >
+            <h1>
+              <FaPlus className="me-2" style={{ fontSize: '18px' }} />
+              Flavour Management
+            </h1>
+            <p>Create and manage data flavours for customized search experiences</p>
+            <button 
+              className="token-close-btn" 
+              onClick={() => this.setState({ showAddFlavourModal: false })}
+            >
+              ×
+            </button>
+          </div>
+
+          <div
+            className="token-section"
+            style={{ 
+              flex: 1, 
+              overflowY: 'auto', 
+              padding: '20px',
+              maxHeight: 'calc(90vh - 160px)'
+            }}
+          >
+            {/* Error Alert */}
+            {this.state.modalError && (
+              <div style={{
+                position: 'sticky',
+                top: '-20px',
+                zIndex: 100,
+                marginBottom: '20px'
+              }}>
+                <Alert
+                  variant="danger"
+                  className="mb-0"
+                  style={{ 
+                    borderRadius: '8px', 
+                    border: 'none', 
+                    backgroundColor: '#fecaca',
+                    color: '#991b1b',
+                    fontSize: '14px',
+                    boxShadow: '0 4px 12px rgba(239, 68, 68, 0.15)'
+                  }}
+                >
+                  {this.state.modalError}
+                </Alert>
+              </div>
+            )}
+
+            {/* Add Flavour Form */}
+            <div>
+              <div className="token-status mb-3">
+                <div className="token-label" style={{ fontSize: '18px' }}>Add New Flavour:</div>
+              </div>
+              
+              <Form onSubmit={this.handleAddFlavour}>
+                {/* Toggle and Flavour Row */}
+                <Row className="mb-3">
+                  <Col md={12}>
+                    <div style={{ display: 'flex', alignItems: 'flex-start', gap: '16px' }}>
+                      {/* Toggle on Left */}
+                      <div style={{ 
+                        display: 'flex', 
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        minWidth: '100px',
+                        maxWidth: '100px'
+                      }}>
+                        <div
+                            style={{ 
+                            display: 'flex', 
+                            flexDirection: 'column',
+                            alignItems: 'center', 
+                            gap: '6px',
+                            padding: '10px',
+                            background: this.state.isGlobal ? '#f0f9ff' : '#f8fafc',
+                            border: `2px solid ${this.state.isGlobal ? '#0ea5e9' : '#e2e8f0'}`,
+                            borderRadius: '10px',
+                            transition: 'all 0.3s ease',
+                            cursor: 'pointer'
+                          }}
+                          onClick={() => this.setState({ isGlobal: !this.state.isGlobal })}
+                        >
+                          {/* Toggle Icon Display */}
+                          <div style={{
+                            width: '24px',
+                            height: '24px',
+                            background: this.state.isGlobal ? '#0ea5e9' : '#6b7280',
+                            borderRadius: '50%',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            transition: 'all 0.3s ease'
+                          }}>
+                            {this.state.isGlobal ? (
+                              <FaGlobe style={{ 
+                                fontSize: '12px', 
+                                color: 'white' 
+                              }} />
+                            ) : (
+                              <FaUser style={{ 
+                                fontSize: '12px', 
+                                color: 'white' 
+                              }} />
+                            )}
+                          </div>
+                          
+                          {/* Toggle Text */}
+                          <span style={{ 
+                            fontSize: '11px', 
+                            fontWeight: '600',
+                            color: this.state.isGlobal ? '#0ea5e9' : '#6b7280',
+                            textAlign: 'center'
+                          }}>
+                            {this.state.isGlobal ? 'Global' : 'Personal'}
+                          </span>
+                          
+                          {/* Toggle Switch */}
+                          <div style={{
+                            width: '36px',
+                            height: '20px',
+                            background: this.state.isGlobal ? '#0ea5e9' : '#cbd5e1',
+                            borderRadius: '10px',
+                            position: 'relative',
+                            transition: 'all 0.3s ease',
+                            boxShadow: 'inset 0 1px 3px rgba(0,0,0,0.1)'
+                          }}>
+                            <div style={{
+                              width: '16px',
+                              height: '16px',
+                              background: 'white',
+                              borderRadius: '50%',
+                              position: 'absolute',
+                              top: '2px',
+                              left: this.state.isGlobal ? '18px' : '2px',
+                              transition: 'all 0.3s ease',
+                              boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center'
+                            }}>
+                              {this.state.isGlobal ? (
+                                <FaGlobe style={{ 
+                                  fontSize: '8px', 
+                                  color: '#0ea5e9' 
+                                }} />
+                              ) : (
+                                <FaUser style={{ 
+                                  fontSize: '8px', 
+                                  color: '#6b7280' 
+                                }} />
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      
+                      {/* Flavour Input */}
+                      <div style={{ flex: 1 }}>
+                        <Form.Group>
+                          <Form.Label style={{ fontWeight: '600', color: '#1e293b', fontSize: '14px', marginBottom: '6px' }}>
+                            Flavour Name
+                          </Form.Label>
+                          <Form.Control
+                            type="text"
+                            value={this.state.flavourName}
+                            onChange={(e) => this.setState({ flavourName: e.target.value })}
+                            placeholder="e.g., nextgem, custom_project"
+                            style={{
+                              border: '2px solid #e2e8f0',
+                              borderRadius: '6px',
+                              padding: '10px 12px',
+                              fontSize: '14px'
+                            }}
+                            required
+                          />
+
+                          {/* Toggle Helper text */}
+                          <div style={{ 
+                            fontSize: '11px', 
+                            color: '#6b7280', 
+                            marginTop: '4px',
+                            fontStyle: 'italic'
+                          }}>
+                            {this.state.isGlobal 
+                              ? " Available to all users (requires admin permissions)" 
+                              : " Personal flavour"
+                            }
+                          </div>
+                        </Form.Group>
+                      </div>
+                    </div>
+                  </Col>
+                </Row>
+
+                <Form.Group className="mb-3">
+                  <Form.Label style={{ fontWeight: '600', color: '#1e293b', fontSize: '14px' }}>
+                    Facet Mappings
+                  </Form.Label>
+                  <div style={{
+                    background: '#f8fafc',
+                    border: '2px solid #e2e8f0',
+                    borderRadius: '8px',
+                    padding: '12px'
+                  }}>
+
+                    <Row>
+                      {availableFacets.map((facet) => (
+                        <Col md={4} key={facet.key} className="mb-2">
+                          <Form.Group>
+                            <Form.Label style={{ fontSize: '11px', color: '#6b7280', marginBottom: '4px', fontWeight: '500' }}>
+                              {facet.label}
+                            </Form.Label>
+                            <Form.Control
+                              type="text"
+                              value={this.state.facetMappings[facet.key]}
+                              onChange={(e) => this.setState({
+                                facetMappings: {
+                                  ...this.state.facetMappings,
+                                  [facet.key]: e.target.value
+                                }
+                              })}
+                              placeholder={`Map ${facet.label.toLowerCase()}`}
+                              style={{
+                                fontSize: '12px',
+                                padding: '6px 8px',
+                                border: '1px solid #e2e8f0',
+                                borderRadius: '4px'
+                              }}
+                            />
+                          </Form.Group>
+                        </Col>
+                      ))}
+                    </Row>
+                    <div style={{
+                      fontSize: '11px',
+                      color: '#6b7280',
+                      fontStyle: 'italic',
+                      marginTop: '8px',
+                      padding: '6px',
+                      background: 'white',
+                      borderRadius: '4px'
+                    }}>
+                      <strong>Example:</strong> For CMIP6 data, you might map &quot;project&quot; to &quot;mip_era&quot;, &quot;model&quot; to &quot;source_id&quot;, etc.
+                    </div>
+                  </div>
+                </Form.Group>
+              </Form>
+            </div>
+          </div>
+
+          {/* Add Flavour Footer Buttons */}
+          <div style={{
+            flexShrink: 0,
+            padding: '16px 20px',
+            borderTop: '1px solid #e2e8f0',
+            background: 'white',
+            borderRadius: '0 0 12px 12px'
+          }}>
+            <div className="token-actions" style={{ margin: 0 }}>
+              <button 
+                type="button"
+                className="token-btn"
+                onClick={() => this.setState({ showAddFlavourModal: false })}
+                style={{ 
+                  background: '#6b7280',
+                  fontSize: '14px',
+                  padding: '10px 16px'
+                }}
+              >
+                Cancel
+              </button>
+              <button 
+                type="submit" 
+                className="token-btn"
+                disabled={this.state.modalLoading}
+                onClick={this.handleAddFlavour}
+                style={{ 
+                  opacity: this.state.modalLoading ? 0.6 : 1,
+                  cursor: this.state.modalLoading ? 'not-allowed' : 'pointer',
+                  fontSize: '14px',
+                  padding: '10px 16px'
+                }}
+              >
+                {this.state.modalLoading ? (
+                  <>
+                    <div style={{
+                      border: '2px solid #f3f4f6',
+                      borderTop: '2px solid white',
+                      borderRadius: '50%',
+                      width: '14px',
+                      height: '14px',
+                      animation: 'spin 1s linear infinite',
+                      marginRight: '6px'
+                    }} />
+                    Adding...
+                  </>
+                ) : (
+                  <>
+                    <FaPlus style={{ fontSize: '12px' }} />
+                    Add Flavour
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <>
+        {this.renderFlavourDropdown()}
+        {/* Add Flavour Modal */}
+        {this.renderAddFlavourModal()}
+        {/* Delete Confirmation Modal */}
+        {this.renderDeleteConfirmModal()}
+        {/* Toast notifications */}
+        <div className="position-fixed top-0 end-0 p-3" style={{ zIndex: 11 }}>
+          <Toast
+            onClose={() => this.setState({ showToast: false })}
+            show={this.state.showToast}
+            delay={3000}
+            style={{ 
+              backgroundColor: this.state.toastVariant === "success" ? "#ddede5" : "#f8d7da" 
+            }}
+            autohide
+          >
+            <Toast.Body>
+              <strong>{this.state.toastMessage}</strong>
+            </Toast.Body>
+          </Toast>
+        </div>
+      </>
+    );
+  }
+}
+
+FlavourManager.propTypes = {
+  flavourDetails: PropTypes.array,
+  currentFlavour: PropTypes.string,
+  defaultFlavour: PropTypes.string,
+  currentUser: PropTypes.string,
+  isAdmin: PropTypes.bool,
+  dispatch: PropTypes.func.isRequired,
+  addFlavour: PropTypes.func.isRequired,
+  deleteFlavour: PropTypes.func.isRequired,
+  onFlavourClick: PropTypes.func.isRequired,
+};
+
+export default FlavourManager;

--- a/assets/js/Containers/Databrowser/actions.js
+++ b/assets/js/Containers/Databrowser/actions.js
@@ -62,7 +62,7 @@ export const setMetadata = (metadata) => ({
 });
 
 export const setFlavours = () => async (dispatch) => {
-  return fetch("/api/freva-nextgen/databrowser/flavours/", {
+  return fetch("/api/freva-nextgen/databrowser/flavours", {
     credentials: "same-origin",
     headers: getAuthHeaders(),
   })
@@ -87,7 +87,7 @@ export const setFlavours = () => async (dispatch) => {
 };
 
 export const addFlavour = (flavourData) => async (dispatch) => {
-  const response = await fetch("/api/freva-nextgen/databrowser/flavours/", {
+  const response = await fetch("/api/freva-nextgen/databrowser/flavours", {
     method: "POST",
     credentials: "same-origin",
     headers: getAuthHeaders(),
@@ -116,7 +116,7 @@ export const addFlavour = (flavourData) => async (dispatch) => {
 export const deleteFlavour =
   (flavourName, isGlobal = false) =>
   async (dispatch) => {
-    const url = `/api/freva-nextgen/databrowser/flavours/${encodeURIComponent(flavourName)}/${isGlobal ? "?is_global=true" : ""}`;
+    const url = `/api/freva-nextgen/databrowser/flavours/${encodeURIComponent(flavourName)}/${isGlobal ? "?is_global=true" : "?is_global=false"}`;
 
     const response = await fetch(url, {
       method: "DELETE",

--- a/assets/js/Containers/Databrowser/actions.js
+++ b/assets/js/Containers/Databrowser/actions.js
@@ -116,7 +116,7 @@ export const addFlavour = (flavourData) => async (dispatch) => {
 export const deleteFlavour =
   (flavourName, isGlobal = false) =>
   async (dispatch) => {
-    const url = `/api/freva-nextgen/databrowser/flavours${encodeURIComponent(flavourName)}/${isGlobal ? "?is_global=true" : "?is_global=false"}`;
+    const url = `/api/freva-nextgen/databrowser/flavours/${encodeURIComponent(flavourName)}${isGlobal ? "?is_global=true" : "?is_global=false"}`;
 
     const response = await fetch(url, {
       method: "DELETE",

--- a/assets/js/Containers/Databrowser/actions.js
+++ b/assets/js/Containers/Databrowser/actions.js
@@ -116,7 +116,7 @@ export const addFlavour = (flavourData) => async (dispatch) => {
 export const deleteFlavour =
   (flavourName, isGlobal = false) =>
   async (dispatch) => {
-    const url = `/api/freva-nextgen/databrowser/flavours/${encodeURIComponent(flavourName)}/${isGlobal ? "?is_global=true" : "?is_global=false"}`;
+    const url = `/api/freva-nextgen/databrowser/flavours${encodeURIComponent(flavourName)}/${isGlobal ? "?is_global=true" : "?is_global=false"}`;
 
     const response = await fetch(url, {
       method: "DELETE",

--- a/assets/js/Containers/Databrowser/actions.js
+++ b/assets/js/Containers/Databrowser/actions.js
@@ -9,15 +9,17 @@ import { prepareSearchParams } from "./utils";
 
 const getTokenFromCookie = () => {
   const cookieString = document.cookie;
-  const hasAuthCookie = cookieString.includes('freva_auth_token=');
+  const hasAuthCookie = cookieString.includes("freva_auth_token=");
 
   if (!hasAuthCookie) {
     return null;
   }
   try {
-    const startIndex = cookieString.indexOf('freva_auth_token=');
-    let cookieValue = cookieString.substring(startIndex + 'freva_auth_token='.length);
-    const semicolonIndex = cookieValue.indexOf(';');
+    const startIndex = cookieString.indexOf("freva_auth_token=");
+    let cookieValue = cookieString.substring(
+      startIndex + "freva_auth_token=".length
+    );
+    const semicolonIndex = cookieValue.indexOf(";");
     if (semicolonIndex !== -1) {
       cookieValue = cookieValue.substring(0, semicolonIndex);
     }
@@ -34,11 +36,11 @@ const getTokenFromCookie = () => {
 
 const getAuthHeaders = () => {
   const tokenData = getTokenFromCookie();
-  const csrfToken = getCookie('csrftoken');
+  const csrfToken = getCookie("csrftoken");
   const headers = {
-    'X-CSRFToken': csrfToken,
-    'Accept': 'application/json',
-    'Content-Type': 'application/json',
+    "X-CSRFToken": csrfToken,
+    Accept: "application/json",
+    "Content-Type": "application/json",
   };
 
   if (tokenData?.access_token) {
@@ -95,7 +97,9 @@ export const addFlavour = (flavourData) => async (dispatch) => {
   if (response.status >= 400) {
     const err = await response.json();
     if (response.status === 403) {
-      throw new Error(err.detail || "You don't have permission to add flavours");
+      throw new Error(
+        err.detail || "You don't have permission to add flavours"
+      );
     } else if (response.status === 409) {
       throw new Error(err.detail || "A flavour with this name already exists");
     } else if (response.status === 400) {
@@ -109,31 +113,35 @@ export const addFlavour = (flavourData) => async (dispatch) => {
   return result;
 };
 
-export const deleteFlavour = (flavourName, isGlobal = false) => async (dispatch) => {
-  const url = `/api/freva-nextgen/databrowser/flavours/${encodeURIComponent(flavourName)}/${isGlobal ? '?is_global=true' : ''}`;
+export const deleteFlavour =
+  (flavourName, isGlobal = false) =>
+  async (dispatch) => {
+    const url = `/api/freva-nextgen/databrowser/flavours/${encodeURIComponent(flavourName)}/${isGlobal ? "?is_global=true" : ""}`;
 
-  const response = await fetch(url, {
-    method: "DELETE",
-    credentials: "same-origin",
-    headers: getAuthHeaders(),
-  });
+    const response = await fetch(url, {
+      method: "DELETE",
+      credentials: "same-origin",
+      headers: getAuthHeaders(),
+    });
 
-  if (response.status >= 400) {
-    const err = await response.json();
-    if (response.status === 403) {
-      throw new Error(err.detail || "You don't have permission to delete this flavour");
-    } else if (response.status === 404) {
-      throw new Error(err.detail || "Flavour not found");
-    } else if (response.status === 409) {
-      throw new Error(err.detail || "Cannot delete built-in flavour");
+    if (response.status >= 400) {
+      const err = await response.json();
+      if (response.status === 403) {
+        throw new Error(
+          err.detail || "You don't have permission to delete this flavour"
+        );
+      } else if (response.status === 404) {
+        throw new Error(err.detail || "Flavour not found");
+      } else if (response.status === 409) {
+        throw new Error(err.detail || "Cannot delete built-in flavour");
+      }
+      throw new Error(err.detail || "Failed to delete flavour");
     }
-    throw new Error(err.detail || "Failed to delete flavour");
-  }
 
-  const result = await response.json();
-  await dispatch(setFlavours());
-  return result;
-};
+    const result = await response.json();
+    await dispatch(setFlavours());
+    return result;
+  };
 
 export const loadFiles = (location) => async (dispatch) => {
   dispatch({ type: constants.SET_FILE_LOADING });

--- a/assets/js/Containers/Databrowser/actions.js
+++ b/assets/js/Containers/Databrowser/actions.js
@@ -7,6 +7,46 @@ import * as globalStateConstants from "../App/constants";
 import * as constants from "./constants";
 import { prepareSearchParams } from "./utils";
 
+const getTokenFromCookie = () => {
+  const cookieString = document.cookie;
+  const hasAuthCookie = cookieString.includes('freva_auth_token=');
+
+  if (!hasAuthCookie) {
+    return null;
+  }
+  try {
+    const startIndex = cookieString.indexOf('freva_auth_token=');
+    let cookieValue = cookieString.substring(startIndex + 'freva_auth_token='.length);
+    const semicolonIndex = cookieValue.indexOf(';');
+    if (semicolonIndex !== -1) {
+      cookieValue = cookieValue.substring(0, semicolonIndex);
+    }
+    if (cookieValue.startsWith('"') && cookieValue.endsWith('"')) {
+      cookieValue = cookieValue.slice(1, -1);
+    }
+    const decodedJson = atob(cookieValue);
+    const tokenData = JSON.parse(decodedJson);
+    return tokenData;
+  } catch (error) {
+    return null;
+  }
+};
+
+const getAuthHeaders = () => {
+  const tokenData = getTokenFromCookie();
+  const csrfToken = getCookie('csrftoken');
+  const headers = {
+    'X-CSRFToken': csrfToken,
+    'Accept': 'application/json',
+    'Content-Type': 'application/json',
+  };
+
+  if (tokenData?.access_token) {
+    headers.Authorization = `Bearer ${tokenData.access_token}`;
+  }
+  return headers;
+};
+
 export const updateFacetSelection = (queryObject) => (dispatch) => {
   dispatch({
     type: constants.UPDATE_FACET_SELECTION,
@@ -19,14 +59,10 @@ export const setMetadata = (metadata) => ({
   metadata,
 });
 
-export const setFlavours = () => (dispatch) => {
-  return fetch("/api/freva-nextgen/databrowser/overview", {
+export const setFlavours = () => async (dispatch) => {
+  return fetch("/api/freva-nextgen/databrowser/flavours/", {
     credentials: "same-origin",
-    headers: {
-      "X-CSRFToken": getCookie("csrftoken"),
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    },
+    headers: getAuthHeaders(),
   })
     .then((response) => {
       if (response.status >= 400) {
@@ -48,7 +84,58 @@ export const setFlavours = () => (dispatch) => {
     });
 };
 
-export const loadFiles = (location) => (dispatch) => {
+export const addFlavour = (flavourData) => async (dispatch) => {
+  const response = await fetch("/api/freva-nextgen/databrowser/flavours/", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: getAuthHeaders(),
+    body: JSON.stringify(flavourData),
+  });
+
+  if (response.status >= 400) {
+    const err = await response.json();
+    if (response.status === 403) {
+      throw new Error(err.detail || "You don't have permission to add flavours");
+    } else if (response.status === 409) {
+      throw new Error(err.detail || "A flavour with this name already exists");
+    } else if (response.status === 400) {
+      throw new Error(err.detail || "Invalid flavour data provided");
+    }
+    throw new Error(err.detail || "Failed to add flavour");
+  }
+
+  const result = await response.json();
+  await dispatch(setFlavours());
+  return result;
+};
+
+export const deleteFlavour = (flavourName, isGlobal = false) => async (dispatch) => {
+  const url = `/api/freva-nextgen/databrowser/flavours/${encodeURIComponent(flavourName)}/${isGlobal ? '?is_global=true' : ''}`;
+
+  const response = await fetch(url, {
+    method: "DELETE",
+    credentials: "same-origin",
+    headers: getAuthHeaders(),
+  });
+
+  if (response.status >= 400) {
+    const err = await response.json();
+    if (response.status === 403) {
+      throw new Error(err.detail || "You don't have permission to delete this flavour");
+    } else if (response.status === 404) {
+      throw new Error(err.detail || "Flavour not found");
+    } else if (response.status === 409) {
+      throw new Error(err.detail || "Cannot delete built-in flavour");
+    }
+    throw new Error(err.detail || "Failed to delete flavour");
+  }
+
+  const result = await response.json();
+  await dispatch(setFlavours());
+  return result;
+};
+
+export const loadFiles = (location) => async (dispatch) => {
   dispatch({ type: constants.SET_FILE_LOADING });
   return fetchResults(
     dispatch,
@@ -58,37 +145,50 @@ export const loadFiles = (location) => (dispatch) => {
   );
 };
 
-function fetchResults(dispatch, location, additionalParams, actionType) {
+async function fetchResults(dispatch, location, additionalParams, actionType) {
   const searchParams = prepareSearchParams(location, additionalParams);
   const url = `/api/freva-nextgen/databrowser/extended-search/${searchParams}`;
-  return fetch(url, {
-    credentials: "same-origin",
-    headers: {
-      "X-CSRFToken": getCookie("csrftoken"),
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    },
-  })
-    .then((response) => {
-      if (response.status >= 400) {
-        throw new Error(response.statusText);
-      }
-      return response.json();
-    })
-    .then((json) => {
-      return dispatch({
-        type: actionType,
-        payload: {
-          ...json,
-          start: location.query.start ?? 0,
-          flavour: location.query.flavour ?? constants.DEFAULT_FLAVOUR,
-        },
-      });
-    })
-    .catch(() => {
-      return dispatch({
-        type: globalStateConstants.SET_ERROR,
-        payload: "Internal Error: Could not load results",
-      });
+
+  try {
+    const headers = getAuthHeaders();
+
+    const response = await fetch(url, {
+      credentials: "same-origin",
+      headers,
     });
+
+    if (response.status >= 400) {
+      if (response.status === 403) {
+        throw new Error("Access denied. Please check your permissions.");
+      } else if (response.status === 404) {
+        throw new Error("Search endpoint not found.");
+      }
+      throw new Error(response.statusText);
+    }
+
+    const json = await response.json();
+    return dispatch({
+      type: actionType,
+      payload: {
+        ...json,
+        start: location.query.start ?? 0,
+        flavour: location.query.flavour ?? constants.DEFAULT_FLAVOUR,
+      },
+    });
+  } catch (error) {
+    let errorMessage = "Internal Error: Could not load results";
+
+    if (error.message.includes("Access denied")) {
+      errorMessage = "Access denied. Please check your authentication.";
+    } else if (error.message.includes("not found")) {
+      errorMessage = "Service temporarily unavailable. Please try again later.";
+    } else if (error.message.includes("Failed to fetch")) {
+      errorMessage = "Network error. Please check your connection.";
+    }
+
+    return dispatch({
+      type: globalStateConstants.SET_ERROR,
+      payload: errorMessage,
+    });
+  }
 }

--- a/assets/js/Containers/Databrowser/actions.js
+++ b/assets/js/Containers/Databrowser/actions.js
@@ -8,24 +8,21 @@ import * as constants from "./constants";
 import { prepareSearchParams } from "./utils";
 
 const getTokenFromCookie = () => {
-  const cookieString = document.cookie;
-  const hasAuthCookie = cookieString.includes("freva_auth_token=");
+  const cookies = document.cookie.split(";");
+  const authCookie = cookies.find((cookie) =>
+    cookie.trim().startsWith(constants.TEMP_FREVA_AUTH_TOKEN)
+  );
 
-  if (!hasAuthCookie) {
+  if (!authCookie) {
     return null;
   }
+
   try {
-    const startIndex = cookieString.indexOf("freva_auth_token=");
-    let cookieValue = cookieString.substring(
-      startIndex + "freva_auth_token=".length
-    );
-    const semicolonIndex = cookieValue.indexOf(";");
-    if (semicolonIndex !== -1) {
-      cookieValue = cookieValue.substring(0, semicolonIndex);
-    }
+    let cookieValue = authCookie.substring(authCookie.indexOf("=") + 1);
     if (cookieValue.startsWith('"') && cookieValue.endsWith('"')) {
       cookieValue = cookieValue.slice(1, -1);
     }
+
     const decodedJson = atob(cookieValue);
     const tokenData = JSON.parse(decodedJson);
     return tokenData;
@@ -87,7 +84,7 @@ export const setFlavours = () => async (dispatch) => {
 };
 
 export const addFlavour = (flavourData) => async (dispatch) => {
-  const response = await fetch("/api/freva-nextgen/databrowser/flavours", {
+  const response = await fetch("/api/freva-nextgen/databrowser/flavours/", {
     method: "POST",
     credentials: "same-origin",
     headers: getAuthHeaders(),

--- a/assets/js/Containers/Databrowser/constants.js
+++ b/assets/js/Containers/Databrowser/constants.js
@@ -23,7 +23,8 @@ export const BBOX_RANGE_FILE = "file";
 export const BBOX_RANGE_FLEXIBLE = "flexible";
 export const BBOX_RANGE_STRICT = "strict";
 
-export const DEFAULT_FLAVOUR = "freva";
+export const DEFAULT_FLAVOUR = window.DEFAULT_FLAVOUR || "freva";
+
 export const BATCH_SIZE = 100;
 export const ViewTypes = {
   RESULT_CENTERED: "RESULT_CENTERED",
@@ -31,3 +32,28 @@ export const ViewTypes = {
 };
 
 export const STREAM_CATALOGUE_MAXIMUM = 100_000;
+export const AVAILABLE_FACETS = [
+  { key: "project", label: "Project" },
+  { key: "model", label: "Model" },
+  { key: "experiment", label: "Experiment" },
+  { key: "variable", label: "Variable" },
+  { key: "institute", label: "Institute" },
+  { key: "time_frequency", label: "Time Frequency" },
+  { key: "cmor_table", label: "CMOR Table" },
+  { key: "ensemble", label: "Ensemble" },
+  { key: "fs_type", label: "File System Type" },
+  { key: "grid_label", label: "Grid Label" },
+  { key: "product", label: "Product" },
+  { key: "realm", label: "Realm" },
+  { key: "time_aggregation", label: "Time Aggregation" },
+  { key: "dataset", label: "Dataset" },
+  { key: "driving_model", label: "Driving Model" },
+  { key: "format", label: "Format" },
+  { key: "grid_id", label: "Grid ID" },
+  { key: "level_type", label: "Level Type" },
+  { key: "rcm_name", label: "RCM Name" },
+  { key: "rcm_version", label: "RCM Version" },
+  { key: "user", label: "User" },
+];
+
+export const TEMP_FREVA_AUTH_TOKEN = "freva_auth_token=";

--- a/assets/js/Containers/Databrowser/index.js
+++ b/assets/js/Containers/Databrowser/index.js
@@ -9,7 +9,6 @@ import {
   Alert,
   OverlayTrigger,
   Tooltip,
-  Form,
   Collapse,
 } from "react-bootstrap";
 import {
@@ -31,6 +30,8 @@ import {
   loadFiles,
   updateFacetSelection,
   setFlavours,
+  addFlavour,
+  deleteFlavour,
 } from "./actions";
 import TimeRangeSelector from "./TimeRangeSelector";
 import FilesPanel from "./FilesPanel";
@@ -45,6 +46,7 @@ import { FacetPanel } from "./FacetPanel";
 import { prepareSearchParams } from "./utils";
 import CatalogExportDropdown from "./CatalogExportDropdown";
 import BBoxSelector from "./BBoxSelector";
+import FlavourManager from "./FlavourManager";
 
 class Databrowser extends React.Component {
   constructor(props) {
@@ -52,15 +54,16 @@ class Databrowser extends React.Component {
     this.clickFacet = this.clickFacet.bind(this);
     this.renderFacetBadges = this.renderFacetBadges.bind(this);
     this.createCatalogLink = this.createCatalogLink.bind(this);
+    this.clickFlavour = this.clickFlavour.bind(this);
     const firstViewPort =
       localStorage.FrevaDatabrowserViewPort ?? ViewTypes.RESULT_CENTERED;
     localStorage.FrevaDatabrowserViewPort = firstViewPort;
+
     this.state = {
       viewPort: firstViewPort,
       additionalFacetsVisible: false,
     };
   }
-
   /**
    * On mount we load all facets and files to display
    * Also load the metadata.js script
@@ -90,7 +93,6 @@ class Databrowser extends React.Component {
       );
     document.body.appendChild(script);
   }
-
   componentDidUpdate(prevProps) {
     if (prevProps.location.search !== this.props.location.search) {
       this.props.dispatch(loadFiles(this.props.location));
@@ -201,6 +203,7 @@ class Databrowser extends React.Component {
         );
       });
   }
+
   dropBBoxSelection() {
     const currentLocation = this.props.location.pathname;
     const {
@@ -397,7 +400,6 @@ class Databrowser extends React.Component {
     const facetPanels = this.renderFacetPanels();
     const additionalFacetPanels = this.renderAdditionalFacets();
     const isFacetCentered = this.state.viewPort === ViewTypes.FACET_CENTERED;
-    const flavour = this.props.location.query.flavour;
 
     return (
       <Container>
@@ -410,32 +412,15 @@ class Databrowser extends React.Component {
               )}
             </h2>
             <div className="d-flex justify-content-between mb-2">
-              <div className="position-relative me-1">
-                <Form.Select
-                  aria-label="Flavour selection"
-                  className="me-1"
-                  value={flavour}
-                  onChange={(x) => {
-                    this.clickFlavour(x.target.value);
-                  }}
-                >
-                  {this.props.databrowser.flavours.map((x) => {
-                    return <option key={x}>{x}</option>;
-                  })}
-                </Form.Select>
-                <small
-                  className="position-absolute text-muted"
-                  style={{
-                    top: "-7px",
-                    left: "2px",
-                    backgroundColor: "white",
-                    padding: "0 4px",
-                    fontSize: "0.7rem",
-                  }}
-                >
-                  flavour
-                </small>
-              </div>
+              <FlavourManager
+                flavourDetails={this.props.databrowser.flavourDetails}
+                currentFlavour={this.props.location.query.flavour}
+                defaultFlavour={DEFAULT_FLAVOUR}
+                dispatch={this.props.dispatch}
+                addFlavour={addFlavour}
+                deleteFlavour={deleteFlavour}
+                onFlavourClick={this.clickFlavour}
+              />
 
               <CatalogExportDropdown
                 disabled={
@@ -544,6 +529,7 @@ Databrowser.propTypes = {
     facets: PropTypes.object,
     files: PropTypes.array,
     flavours: PropTypes.array,
+    flavourDetails: PropTypes.array,
     fileLoading: PropTypes.bool,
     facetLoading: PropTypes.bool,
     facetMapping: PropTypes.object,

--- a/assets/js/Containers/Databrowser/reducers.js
+++ b/assets/js/Containers/Databrowser/reducers.js
@@ -18,6 +18,7 @@ const databrowserInitialState = {
   facetLoading: false,
   fileLoading: false,
   flavours: ["freva"],
+  flavourDetails: [],
   selectedFlavour: constants.DEFAULT_FLAVOUR,
 };
 
@@ -84,8 +85,15 @@ export const databrowserReducer = (state = databrowserInitialState, action) => {
     }
     case constants.SET_METADATA:
       return { ...state, metadata: action.metadata };
-    case constants.SET_FLAVOURS:
-      return { ...state, flavours: action.payload.flavours };
+    case constants.SET_FLAVOURS: {
+      const flavourDetails = action.payload.flavours || [];
+      const flavourNames = flavourDetails.map(f => f.flavour_name);
+      return {
+        ...state,
+        flavours: flavourNames,
+        flavourDetails
+      };
+    }
     case constants.LOAD_FILES:
       return {
         ...state,

--- a/assets/js/Containers/Databrowser/reducers.js
+++ b/assets/js/Containers/Databrowser/reducers.js
@@ -87,11 +87,11 @@ export const databrowserReducer = (state = databrowserInitialState, action) => {
       return { ...state, metadata: action.metadata };
     case constants.SET_FLAVOURS: {
       const flavourDetails = action.payload.flavours || [];
-      const flavourNames = flavourDetails.map(f => f.flavour_name);
+      const flavourNames = flavourDetails.map((f) => f.flavour_name);
       return {
         ...state,
         flavours: flavourNames,
-        flavourDetails
+        flavourDetails,
       };
     }
     case constants.LOAD_FILES:

--- a/base/views.py
+++ b/base/views.py
@@ -38,26 +38,8 @@ LOGIN_URL = '/api/freva-nextgen/auth/v2/login'
 def set_token_cookie(response, token_data):
     """
     Set secure token cookies;
-    - HttpOnly cookie for refresh token (server-side only)
     - Separate cookie for access token (JavaScript accessible).
     """
-    refresh_cookie_data = {
-        'refresh_token': token_data['refresh_token'],
-        'refresh_expires': token_data['refresh_expires'],
-    }
-
-    json_string = json.dumps(refresh_cookie_data, separators=(',', ':'))
-    encoded_refresh = base64.b64encode(json_string.encode('utf-8')).decode('ascii')
-
-    response.set_cookie(
-        'freva_refresh_token',
-        encoded_refresh,
-        max_age=token_data['refresh_expires'] - int(time.time()),
-        httponly=True,
-        secure=True,
-        samesite='Strict'
-    )
-
     access_cookie_data = {
         'access_token': token_data['access_token'],
         'token_type': 'Bearer',

--- a/base/views.py
+++ b/base/views.py
@@ -1,9 +1,11 @@
+import base64
 import glob
+import json
 import logging
 import os
 import time
 from urllib.parse import urlencode, urlparse, urlunparse
-import json
+
 import requests
 from django.conf import settings
 from django.contrib.auth import authenticate, login
@@ -16,7 +18,7 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from evaluation_system.misc import config
-import base64
+
 from base.models import UIMessages
 from django_evaluation.monitor import _restart
 

--- a/base/views.py
+++ b/base/views.py
@@ -3,7 +3,7 @@ import logging
 import os
 import time
 from urllib.parse import urlencode, urlparse, urlunparse
-
+import json
 import requests
 from django.conf import settings
 from django.contrib.auth import authenticate, login
@@ -16,7 +16,7 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from evaluation_system.misc import config
-
+import base64
 from base.models import UIMessages
 from django_evaluation.monitor import _restart
 
@@ -33,6 +33,49 @@ def ensure_url_scheme(url, default_scheme='http'):
 TOKEN_URL = ensure_url_scheme(settings.FREVA_REST_URL).rstrip('/') + '/api/freva-nextgen/auth/v2/token'
 LOGIN_URL = '/api/freva-nextgen/auth/v2/login'
 
+def set_token_cookie(response, token_data):
+    """
+    Set secure token cookies;
+    - HttpOnly cookie for refresh token (server-side only)
+    - Separate cookie for access token (JavaScript accessible).
+    """
+    refresh_cookie_data = {
+        'refresh_token': token_data['refresh_token'],
+        'refresh_expires': token_data['refresh_expires'],
+    }
+
+    json_string = json.dumps(refresh_cookie_data, separators=(',', ':'))
+    encoded_refresh = base64.b64encode(json_string.encode('utf-8')).decode('ascii')
+
+    response.set_cookie(
+        'freva_refresh_token',
+        encoded_refresh,
+        max_age=token_data['refresh_expires'] - int(time.time()),
+        httponly=True,
+        secure=True,
+        samesite='Strict'
+    )
+
+    access_cookie_data = {
+        'access_token': token_data['access_token'],
+        'token_type': 'Bearer',
+        'expires': token_data['expires'],
+        'scope': 'openid profile'
+    }
+
+    json_string = json.dumps(access_cookie_data, separators=(',', ':'))
+    encoded_access = base64.b64encode(json_string.encode('utf-8')).decode('ascii')
+
+    response.set_cookie(
+        'freva_auth_token',
+        encoded_access,
+        max_age=token_data['expires'] - int(time.time()),
+        httponly=False,
+        secure=True,
+        samesite='Strict'
+    )
+
+    return response
 
 class OIDCLoginView(View):
     """
@@ -93,25 +136,19 @@ class OIDCCallbackView(View):
                 request.session['refresh_token'] = token_data['refresh_token']
                 request.session['token_expires'] = token_data['expires']
                 request.session['refresh_expires'] = token_data['refresh_expires']
-                # Authenticate user using the access token
-                user = authenticate(
-                    request=request,
-                    access_token=token_data['access_token']
-                )
+
+                # Authenticate user
+                user = authenticate(request=request, access_token=token_data['access_token'])
                 if user:
                     login(request, user)
                     next_url = request.session.pop('login_next', '/')
-                    # Validate next URL
+
                     if url_has_allowed_host_and_scheme(next_url, allowed_hosts=request.get_host()):
                         response = HttpResponseRedirect(next_url)
                     else:
                         response = HttpResponseRedirect('/')
-                    response.set_cookie(
-                        'freva_auth_token', 
-                        f"Bearer {token_data['access_token']}",
-                        httponly=True,
-                        secure=True  # if using HTTPS
-                    )
+
+                    response = set_token_cookie(response, token_data)
                     return response
                 else:
                     logger.error("User authentication failed despite valid token")
@@ -167,7 +204,11 @@ def logout_view(request):
     # Django backend logout
     auth_logout(request)
 
-    return HttpResponseRedirect("/")
+    response = HttpResponseRedirect("/")
+    # clear cookies set by Freva
+    response.delete_cookie('freva_auth_token', path='/', samesite='Strict')
+    response.delete_cookie('freva_refresh_token', path='/', samesite='Strict')
+    return response
 
 
 @csrf_exempt
@@ -224,20 +265,21 @@ def manual_refresh_token(request):
             request.session['refresh_token'] = token_data['refresh_token']
             request.session['token_expires'] = token_data['expires']
             request.session['refresh_expires'] = token_data['refresh_expires']
-
             # pop last_refresh_attempt to reset cooldown
             request.session.pop('last_refresh_attempt', None)
             request.session.modified = True
 
             logger.info(f"Manual token refresh successful for user {request.user.username}")
-
-            return JsonResponse({
+            # initi response to set cookie, then return JSON
+            json_response = JsonResponse({
                 'success': True,
                 'access_token': token_data['access_token'],
                 'expires': token_data['expires'],
                 'expires_in': token_data['expires'] - int(time.time()),
                 'message': 'Token refreshed successfully'
             })
+            json_response = set_token_cookie(json_response, token_data)
+            return json_response
         else:
             logger.error(f"Manual token refresh failed: {response.status_code} - {response.text}")
             return JsonResponse({

--- a/django_evaluation/middelwares.py
+++ b/django_evaluation/middelwares.py
@@ -1,15 +1,17 @@
 """middleware for handling OAuth2 token refresh and plugin reloading."""
 
+import base64
+import json
 import logging
 import time
-import json
+
 import requests
 from django.conf import settings
 from django.contrib.auth import logout
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from evaluation_system.api import plugin_manager as pm
-import base64
+
 from base.views import TOKEN_URL, set_token_cookie
 
 logger = logging.getLogger(__name__)

--- a/django_evaluation/middelwares.py
+++ b/django_evaluation/middelwares.py
@@ -2,15 +2,15 @@
 
 import logging
 import time
-
+import json
 import requests
 from django.conf import settings
 from django.contrib.auth import logout
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from evaluation_system.api import plugin_manager as pm
-
-from base.views import TOKEN_URL
+import base64
+from base.views import TOKEN_URL, set_token_cookie
 
 logger = logging.getLogger(__name__)
 
@@ -35,21 +35,50 @@ class OIDCTokenRefreshMiddleware:
             return self.get_response(request)
 
         # Check if user is authenticated and has tokens in session
+        token_refreshed = False
+
         if (request.user.is_authenticated and 
             'access_token' in request.session and 
             'refresh_token' in request.session):
 
             # Only check token expiry, don't refresh immediately
             if self._is_token_expired_or_expiring_soon(request):
-                # Check if we recently attempted a refresh
                 if not self._is_refresh_on_cooldown(request):
-                    if not self._refresh_token(request):
-                        # Refresh failed, logout user and redirect to login
+                    refresh_result = self._refresh_token(request)
+                    if refresh_result is False:
                         logger.warning(f"Token refresh failed for user {request.user.username}, logging out")
                         logout(request)
                         return HttpResponseRedirect("/")
+                    elif refresh_result is True:
+                        token_refreshed = True
 
-        return self.get_response(request)
+        response = self.get_response(request)
+
+        # update cookies with refreshed tokens
+        if token_refreshed and request.user.is_authenticated:
+            self._update_token_cookie(response, request)
+
+        return response
+    def _update_token_cookie(self, response, request):
+        """
+        Update token cookies with refreshed data
+        """
+        try:
+            access_token = request.session.get('access_token')
+            refresh_token = request.session.get('refresh_token')
+            expires = request.session.get('token_expires')
+            refresh_expires = request.session.get('refresh_expires')
+
+            if access_token and expires:
+                token_data = {
+                    'access_token': access_token,
+                    'refresh_token': refresh_token,
+                    'expires': expires,
+                    'refresh_expires': refresh_expires
+                }
+                response = set_token_cookie(response, token_data)
+        except Exception as e:
+            logger.warning(f"Failed to update token cookies: {e}")
 
     def _is_token_expired_or_expiring_soon(self, request):
         """

--- a/django_evaluation/settings/local.py
+++ b/django_evaluation/settings/local.py
@@ -17,6 +17,7 @@ ALLOWED_HOSTS : str
 CSRF_TRUSTED_ORIGINS : str
 FREVA_BIN: str
 STAC_BROWSER: 0|1
+DEFAULT_FLAVOUR: str
 """
 
 import logging
@@ -154,6 +155,7 @@ IMPRINT = web_config.get("imprint") or [
 HOMEPAGE_HEADING = web_config.get("homepage_heading") or "Lorem ipsum dolor."
 ABOUT_US_TEXT = web_config.get("about_us_text") or "Hello world, this is freva."
 CONTACTS = web_config.get("contacts") or ["freva@dkrz.de"]
+DEFAULT_FLAVOUR = web_config.get("DEFAULT_FLAVOUR", "cmip6")
 if isinstance(CONTACTS, str):
     CONTACTS = [c for c in CONTACTS.split(",") if c.strip()]
 ##########

--- a/django_evaluation/settings/local.py
+++ b/django_evaluation/settings/local.py
@@ -155,7 +155,7 @@ IMPRINT = web_config.get("imprint") or [
 HOMEPAGE_HEADING = web_config.get("homepage_heading") or "Lorem ipsum dolor."
 ABOUT_US_TEXT = web_config.get("about_us_text") or "Hello world, this is freva."
 CONTACTS = web_config.get("contacts") or ["freva@dkrz.de"]
-DEFAULT_FLAVOUR = web_config.get("DEFAULT_FLAVOUR", "cmip6")
+DEFAULT_FLAVOUR = web_config.get("DEFAULT_FLAVOUR", "freva")
 if isinstance(CONTACTS, str):
     CONTACTS = [c for c in CONTACTS.split(",") if c.strip()]
 ##########

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react-dom": "^16.14.0",
         "react-highlight": "^0.15.0",
         "react-html-parser": "^2.0.2",
-        "react-icons": "^4.3.1",
+        "react-icons": "^4.12.0",
         "react-markdown": "^8.0.7",
         "react-nl2br": "^1.0.2",
         "react-redux": "^7.2.6",
@@ -9273,9 +9273,10 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
-      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*"
       }
@@ -18554,9 +18555,9 @@
       }
     },
     "react-icons": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
-      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
       "requires": {}
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-dom": "^16.14.0",
     "react-highlight": "^0.15.0",
     "react-html-parser": "^2.0.2",
-    "react-icons": "^4.3.1",
+    "react-icons": "^4.12.0",
     "react-markdown": "^8.0.7",
     "react-nl2br": "^1.0.2",
     "react-redux": "^7.2.6",

--- a/templates/_layouts/base.html
+++ b/templates/_layouts/base.html
@@ -1,4 +1,5 @@
 {% load bootstrap5 %}
+{% load settingstags %}
 
 <!doctype html>
 <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
@@ -57,10 +58,13 @@
         <!-- All JavaScript at the bottom, except this Modernizr build.
        Modernizr enables HTML5 elements & feature detects for optimal performance.
        Create your own custom Modernizr build: www.modernizr.com/download/ -->
+
         <script src="{{ STATIC_URL }}js/libs/modernizr-2.6.2-respond-1.1.0.min.js"></script>
 
         <!-- JavaScript at the bottom for fast page loading -->
-
+        <script>
+            window.DEFAULT_FLAVOUR = "{% settings_val 'DEFAULT_FLAVOUR' %}";
+        </script>
         {% bootstrap_javascript%}
         <script src="{{ STATIC_URL }}js/documentcloud-visualsearch-4550d61/build-min/dependencies.js" type="text/javascript"></script>
 


### PR DESCRIPTION
This PR introduces a small feature for users and admins in freva-based projects to manage their desired flavors through an authenticated endpoint.

how works:

```mermaid
graph TD
    A[Middleware or Re-new token] --> B[Issue access token and store it in the Browser cookie]
    B --> C[action.js retrieves token from cookie, include in the header of flavour endpoints]
    C --> D[Serve personal flavors]
```
There was another approach to do:
We could use the existing `/get-current-token` endpoint with async calls in auth headers(as we do currently in gpt front end). but, this approach was rejected because, the endpoint is tightly coupled to Django REST Framework while on the other hand cookie-based token management provides a more framework-agnostic solution that will scale better when we migrate from django.

You can test the feature in the sandbox:
flavour drop down in https://freva-sandbox.cloud.dkrz.de/databrowser/

