### PR TITLE
Fix and release: Fix a list of flavour and auth related issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 
 
 All notable changes to this project will be documented in this file.
+## [v2509.0.0]
+## Added
+- Add a functionality to add, remove, and list the custom flavours, from new API endpoint of the Freva-rest
+- Adopted scrolling in FrevaGPT
+
+## Changed
+- changed the logic of the default_flavour to handle edge cases in Custom Flavour
+- change the prompt from `login` to `none` in redirect callback authorization
+- Refactor FrevaGPT components
+
 
 ## [v2507.0.0]
 ## Added

--- a/assets/js/Containers/Databrowser/DataBrowserCommand.js
+++ b/assets/js/Containers/Databrowser/DataBrowserCommand.js
@@ -56,7 +56,10 @@ function DataBrowserCommandImpl(props) {
   }
 
   function getFullCliCommand(dateSelectorToCli, bboxSelectorToCli) {
-    const effectiveFlavour = props.selectedFlavour || window.EFFECTIVE_DEFAULT_FLAVOUR || constants.DEFAULT_FLAVOUR;
+    const effectiveFlavour =
+      props.selectedFlavour ||
+      window.EFFECTIVE_DEFAULT_FLAVOUR ||
+      constants.DEFAULT_FLAVOUR;
     return (
       "freva-client databrowser data-search " +
       (props.minDate ? `time=${props.minDate}to${props.maxDate} ` : "") +
@@ -82,7 +85,10 @@ function DataBrowserCommandImpl(props) {
   function renderCLICommand() {
     const dateSelectorToCli = getCliTimeSelector();
     const bboxSelectorToCli = getCliBBoxSelector();
-    const effectiveFlavour = props.selectedFlavour || window.EFFECTIVE_DEFAULT_FLAVOUR || constants.DEFAULT_FLAVOUR;
+    const effectiveFlavour =
+      props.selectedFlavour ||
+      window.EFFECTIVE_DEFAULT_FLAVOUR ||
+      constants.DEFAULT_FLAVOUR;
 
     return (
       <pre className="mb-1" style={{ whiteSpace: "pre-wrap" }}>
@@ -135,7 +141,10 @@ function DataBrowserCommandImpl(props) {
 
   function getFullPythonCommand(dateSelectorToCli, bboxSelectorToCli) {
     let args = [];
-    const effectiveFlavour = props.selectedFlavour || window.EFFECTIVE_DEFAULT_FLAVOUR || constants.DEFAULT_FLAVOUR;
+    const effectiveFlavour =
+      props.selectedFlavour ||
+      window.EFFECTIVE_DEFAULT_FLAVOUR ||
+      constants.DEFAULT_FLAVOUR;
     // if it's only freva, we don't need to specify flavour=, in
     // all other cases we do
     if (effectiveFlavour !== "freva") {

--- a/assets/js/Containers/Databrowser/DataBrowserCommand.js
+++ b/assets/js/Containers/Databrowser/DataBrowserCommand.js
@@ -56,7 +56,7 @@ function DataBrowserCommandImpl(props) {
   }
 
   function getFullCliCommand(dateSelectorToCli, bboxSelectorToCli) {
-    const effectiveFlavour = props.selectedFlavour || constants.DEFAULT_FLAVOUR;
+    const effectiveFlavour = props.selectedFlavour || window.EFFECTIVE_DEFAULT_FLAVOUR || constants.DEFAULT_FLAVOUR;
     return (
       "freva-client databrowser data-search " +
       (props.minDate ? `time=${props.minDate}to${props.maxDate} ` : "") +
@@ -82,7 +82,7 @@ function DataBrowserCommandImpl(props) {
   function renderCLICommand() {
     const dateSelectorToCli = getCliTimeSelector();
     const bboxSelectorToCli = getCliBBoxSelector();
-    const effectiveFlavour = props.selectedFlavour || constants.DEFAULT_FLAVOUR;
+    const effectiveFlavour = props.selectedFlavour || window.EFFECTIVE_DEFAULT_FLAVOUR || constants.DEFAULT_FLAVOUR;
 
     return (
       <pre className="mb-1" style={{ whiteSpace: "pre-wrap" }}>
@@ -135,7 +135,7 @@ function DataBrowserCommandImpl(props) {
 
   function getFullPythonCommand(dateSelectorToCli, bboxSelectorToCli) {
     let args = [];
-    const effectiveFlavour = props.selectedFlavour || constants.DEFAULT_FLAVOUR;
+    const effectiveFlavour = props.selectedFlavour || window.EFFECTIVE_DEFAULT_FLAVOUR || constants.DEFAULT_FLAVOUR;
     // if it's only freva, we don't need to specify flavour=, in
     // all other cases we do
     if (effectiveFlavour !== "freva") {

--- a/assets/js/Containers/Databrowser/actions.js
+++ b/assets/js/Containers/Databrowser/actions.js
@@ -84,7 +84,7 @@ export const setFlavours = () => async (dispatch) => {
 };
 
 export const addFlavour = (flavourData) => async (dispatch) => {
-  const response = await fetch("/api/freva-nextgen/databrowser/flavours/", {
+  const response = await fetch("/api/freva-nextgen/databrowser/flavours", {
     method: "POST",
     credentials: "same-origin",
     headers: getAuthHeaders(),

--- a/assets/js/Containers/Databrowser/index.js
+++ b/assets/js/Containers/Databrowser/index.js
@@ -43,7 +43,7 @@ import {
   STREAM_CATALOGUE_MAXIMUM,
 } from "./constants";
 import { FacetPanel } from "./FacetPanel";
-import { prepareSearchParams } from "./utils";
+import { prepareSearchParams, verifyAndSetDefaultFlavour } from "./utils";
 import CatalogExportDropdown from "./CatalogExportDropdown";
 import BBoxSelector from "./BBoxSelector";
 import FlavourManager from "./FlavourManager";
@@ -69,9 +69,20 @@ class Databrowser extends React.Component {
    * Also load the metadata.js script
    */
   componentDidMount() {
-    this.props.dispatch(setFlavours());
-    this.props.dispatch(loadFiles(this.props.location));
-    this.props.dispatch(updateFacetSelection(this.props.location.query));
+    // load flavours, verify default, ensure loadFiles() runs (either success or fallback),
+    // then update facet selection exactly once.
+    this.props
+    .dispatch(setFlavours())
+    .then(() => verifyAndSetDefaultFlavour())
+    .then(() => this.props.dispatch(loadFiles(this.props.location)))
+    .catch(() => {
+      return this.props.dispatch(loadFiles(this.props.location));
+    })
+    .then(() =>
+      this.props.dispatch(updateFacetSelection(this.props.location.query))
+    )
+    .catch(() => {});
+  
     const script = document.createElement("script");
     script.src = "/static/js/metadata.js";
     script.async = true;
@@ -400,7 +411,8 @@ class Databrowser extends React.Component {
     const facetPanels = this.renderFacetPanels();
     const additionalFacetPanels = this.renderAdditionalFacets();
     const isFacetCentered = this.state.viewPort === ViewTypes.FACET_CENTERED;
-
+    // eslint-disable-next-line no-console
+    console.log(window.EFFECTIVE_DEFAULT_FLAVOUR || DEFAULT_FLAVOUR)
     return (
       <Container>
         <Row>
@@ -415,7 +427,7 @@ class Databrowser extends React.Component {
               <FlavourManager
                 flavourDetails={this.props.databrowser.flavourDetails}
                 currentFlavour={this.props.location.query.flavour}
-                defaultFlavour={DEFAULT_FLAVOUR}
+                defaultFlavour={window.EFFECTIVE_DEFAULT_FLAVOUR || DEFAULT_FLAVOUR}
                 dispatch={this.props.dispatch}
                 addFlavour={addFlavour}
                 deleteFlavour={deleteFlavour}

--- a/assets/js/Containers/Databrowser/index.js
+++ b/assets/js/Containers/Databrowser/index.js
@@ -72,17 +72,17 @@ class Databrowser extends React.Component {
     // load flavours, verify default, ensure loadFiles() runs (either success or fallback),
     // then update facet selection exactly once.
     this.props
-    .dispatch(setFlavours())
-    .then(() => verifyAndSetDefaultFlavour())
-    .then(() => this.props.dispatch(loadFiles(this.props.location)))
-    .catch(() => {
-      return this.props.dispatch(loadFiles(this.props.location));
-    })
-    .then(() =>
-      this.props.dispatch(updateFacetSelection(this.props.location.query))
-    )
-    .catch(() => {});
-  
+      .dispatch(setFlavours())
+      .then(() => verifyAndSetDefaultFlavour())
+      .then(() => this.props.dispatch(loadFiles(this.props.location)))
+      .catch(() => {
+        return this.props.dispatch(loadFiles(this.props.location));
+      })
+      .then(() =>
+        this.props.dispatch(updateFacetSelection(this.props.location.query))
+      )
+      .catch(() => {});
+
     const script = document.createElement("script");
     script.src = "/static/js/metadata.js";
     script.async = true;
@@ -411,8 +411,6 @@ class Databrowser extends React.Component {
     const facetPanels = this.renderFacetPanels();
     const additionalFacetPanels = this.renderAdditionalFacets();
     const isFacetCentered = this.state.viewPort === ViewTypes.FACET_CENTERED;
-    // eslint-disable-next-line no-console
-    console.log(window.EFFECTIVE_DEFAULT_FLAVOUR || DEFAULT_FLAVOUR)
     return (
       <Container>
         <Row>
@@ -427,7 +425,9 @@ class Databrowser extends React.Component {
               <FlavourManager
                 flavourDetails={this.props.databrowser.flavourDetails}
                 currentFlavour={this.props.location.query.flavour}
-                defaultFlavour={window.EFFECTIVE_DEFAULT_FLAVOUR || DEFAULT_FLAVOUR}
+                defaultFlavour={
+                  window.EFFECTIVE_DEFAULT_FLAVOUR || DEFAULT_FLAVOUR
+                }
                 dispatch={this.props.dispatch}
                 addFlavour={addFlavour}
                 deleteFlavour={deleteFlavour}

--- a/assets/js/Containers/Databrowser/reducers.js
+++ b/assets/js/Containers/Databrowser/reducers.js
@@ -19,7 +19,7 @@ const databrowserInitialState = {
   fileLoading: false,
   flavours: ["freva"],
   flavourDetails: [],
-  selectedFlavour: constants.DEFAULT_FLAVOUR,
+  selectedFlavour: window.EFFECTIVE_DEFAULT_FLAVOUR,
 };
 
 export const databrowserReducer = (state = databrowserInitialState, action) => {
@@ -68,6 +68,7 @@ export const databrowserReducer = (state = databrowserInitialState, action) => {
         myMinLat = databrowserInitialState.minLat;
         myMaxLat = databrowserInitialState.maxLat;
       }
+      console.log("Reducer flavour:", flavour + " default:", databrowserInitialState.selectedFlavour);
       return {
         ...state,
         selectedFacets: { ...queryObject },
@@ -80,7 +81,7 @@ export const databrowserReducer = (state = databrowserInitialState, action) => {
         maxLon: myMaxLon,
         minLat: myMinLat,
         maxLat: myMaxLat,
-        selectedFlavour: flavour || databrowserInitialState.selectedFlavour,
+        selectedFlavour: flavour || databrowserInitialState.selectedFlavour
       };
     }
     case constants.SET_METADATA:

--- a/assets/js/Containers/Databrowser/reducers.js
+++ b/assets/js/Containers/Databrowser/reducers.js
@@ -68,7 +68,6 @@ export const databrowserReducer = (state = databrowserInitialState, action) => {
         myMinLat = databrowserInitialState.minLat;
         myMaxLat = databrowserInitialState.maxLat;
       }
-      console.log("Reducer flavour:", flavour + " default:", databrowserInitialState.selectedFlavour);
       return {
         ...state,
         selectedFacets: { ...queryObject },
@@ -81,7 +80,7 @@ export const databrowserReducer = (state = databrowserInitialState, action) => {
         maxLon: myMaxLon,
         minLat: myMinLat,
         maxLat: myMaxLat,
-        selectedFlavour: flavour || databrowserInitialState.selectedFlavour
+        selectedFlavour: flavour || databrowserInitialState.selectedFlavour,
       };
     }
     case constants.SET_METADATA:

--- a/assets/js/Containers/Databrowser/utils.js
+++ b/assets/js/Containers/Databrowser/utils.js
@@ -4,7 +4,8 @@ import * as constants from "./constants";
 
 export function prepareSearchParams(location, additionalParams = "") {
   let params = "";
-  let flavourValue = window.EFFECTIVE_DEFAULT_FLAVOUR || constants.DEFAULT_FLAVOUR;
+  let flavourValue =
+    window.EFFECTIVE_DEFAULT_FLAVOUR || constants.DEFAULT_FLAVOUR;
 
   if (location) {
     const queryObject = location.query;
@@ -42,8 +43,11 @@ export function prepareSearchParams(location, additionalParams = "") {
   return `${flavourValue}/file?${additionalParams}${params}`;
 }
 
-
 export async function verifyAndSetDefaultFlavour() {
+  // In this function to ensure that the flavour, exists on the backend
+  // first we query the available flavours from the backend
+  // then we check if window.DEFAULT_FLAVOUR is in the list
+  // if yes, we set window.EFFECTIVE_DEFAULT_FLAVOUR to it
   try {
     const resp = await fetch("/api/freva-nextgen/databrowser/flavours", {
       credentials: "same-origin",

--- a/base/views.py
+++ b/base/views.py
@@ -79,7 +79,7 @@ class OIDCLoginView(View):
 
         params = {
             'redirect_uri': callback_url,
-            'prompt': 'login'
+            'prompt': 'none'
         }
 
         proxy_path = f"/api/freva-nextgen/auth/v2/login?{urlencode(params)}"

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -19,6 +19,7 @@ dependencies:
   - pygtail
   - redis-py
   - toml
+  - unidecode
   - pip:
       - django-datatable-view
       - django-templated-email
@@ -27,4 +28,4 @@ dependencies:
       - django-bootstrap-v5
       - django-model-utils
       - djproxy
-      - unidecode
+

--- a/dev-env.yml
+++ b/dev-env.yml
@@ -43,6 +43,7 @@ dependencies:
     - types-requests
     - types-toml
     - hurry.filesize
+    - unidecode
   - pygtail
   - pylint
   - pyjwt

--- a/django_evaluation/settings/local.py
+++ b/django_evaluation/settings/local.py
@@ -155,7 +155,7 @@ IMPRINT = web_config.get("imprint") or [
 HOMEPAGE_HEADING = web_config.get("homepage_heading") or "Lorem ipsum dolor."
 ABOUT_US_TEXT = web_config.get("about_us_text") or "Hello world, this is freva."
 CONTACTS = web_config.get("contacts") or ["freva@dkrz.de"]
-DEFAULT_FLAVOUR = web_config.get("DEFAULT_FLAVOUR", "freva")
+DEFAULT_FLAVOUR = web_config.get("DEFAULT_FLAVOUR") or os.getenv("DEFAULT_FLAVOUR") or "freva"
 if isinstance(CONTACTS, str):
     CONTACTS = [c for c in CONTACTS.split(",") if c.strip()]
 ##########

--- a/solr/urls.py
+++ b/solr/urls.py
@@ -13,16 +13,21 @@ from django.urls import path
 from django.urls import re_path as url
 
 from .proxyviews import DataBrowserProxy
-from .views import databrowser
+from .views import databrowser, flavours_all_methods
 
 urlpatterns = [
     url(r"^databrowser/$", databrowser, name="data_browser"),
 ]
 if int(os.environ.get("DEV_MODE", "0")) == 1:
-    urlpatterns.append(
+    urlpatterns.extend([
+        url(
+            r"^api/freva-nextgen/databrowser/flavours$",
+            flavours_all_methods,
+            name="flavours_no_slash",
+        ),
         path(
             r"api/freva-nextgen/databrowser/<path:url>/",
             DataBrowserProxy.as_view(),
             name="databrowser_proxy",
-        )
-    )
+        ),
+    ])


### PR DESCRIPTION
There was one important issue with flavours that via this PR we are going to fix it. 
We didn't consider one specific scenario that, what if an admin, set a **wrong** `DEFAULT_FLAVOUR` in the config file of web on production deployment instance but in the meanwhile admin already added a **correct** flavour name in the list of flavours. 
Or another way, if admin sets a `DEFAULT_FLAVOUR`, but it didn't create the flavour yet on the databrowser. It was a scenario that could break the functionality of flavours on databrowser

There were two more minor issues regarding the auth and the flavour tail slash in POST method, that are fixed here.